### PR TITLE
Remove asynchronous operators.

### DIFF
--- a/riak_test/derflow_map_reduce_failure_test.erl
+++ b/riak_test/derflow_map_reduce_failure_test.erl
@@ -40,8 +40,7 @@ test() ->
     {id, Output} = derflow:declare(),
     Supervisor = derflow:thread(map_reduce, supervisor, [dict:new()]),
     jobtracker(Supervisor, Map, Reduce, Input, [Output]),
-    io:format("Final out ~w~n", [Output]),
-    derflow:async_print_stream(Output).
+    io:format("Final out ~w~n", [Output]).
 
 jobtracker(Supervisor, MapTasks, ReduceTasks, Inputs, Outputs) ->
     case MapTasks of

--- a/riak_test/derflow_map_reduce_test.erl
+++ b/riak_test/derflow_map_reduce_test.erl
@@ -65,7 +65,6 @@ jobtracker(Supervisor, Tasks) ->
             MapOut = spawnmap(Supervisor, Input, MapMod, MapFun, []),
             derflow:thread_mon(Supervisor, ReduceMod, ReduceFun,
                                [MapOut, [], Output]),
-            derflow:async_print_stream(Output),
             jobtracker(Supervisor, Next)
     end.
 

--- a/riak_test/derflow_monitor_ports_test.erl
+++ b/riak_test/derflow_monitor_ports_test.erl
@@ -40,8 +40,7 @@ test()->
     derflow:thread(?MODULE, sensor, [Port, dc_2]),
     derflow:thread(?MODULE, sensor, [Port, dc_3]),
     {ok, S2} = derflow:declare(),
-    derflow:thread(?MODULE, dcs_monitor, [S1, S2, []]),
-    derflow:async_print_stream(S2).
+    derflow:thread(?MODULE, dcs_monitor, [S1, S2, []]).
 
 run_port(Stream) ->
     receive

--- a/src/derflow.erl
+++ b/src/derflow.erl
@@ -2,9 +2,7 @@
 -include("derflow.hrl").
 -include_lib("riak_core/include/riak_core_vnode.hrl").
 
--export([async_bind/2,
-         async_bind/3,
-         bind/2,
+-export([bind/2,
          bind/3,
          read/1,
          touch/1,
@@ -14,16 +12,9 @@
          thread_mon/4,
          thread/3,
          wait_needed/1,
-         get_stream/1,
-         async_print_stream/1]).
+         get_stream/1]).
 
 %% Public API
-
-async_bind(Id, Value) ->
-    derflow_vnode:async_bind(Id, Value).
-
-async_bind(Id, Function, Args) ->
-    derflow_vnode:async_bind(Id, Function, Args).
 
 bind(Id, Value) ->
     derflow_vnode:bind(Id, Value).
@@ -59,17 +50,6 @@ thread(Module, Function, Args) ->
 
 get_stream(Stream)->
     internal_get_stream(Stream, []).
-
-async_print_stream(Stream)->
-    case read(Stream) of
-        {ok, nil, _} ->
-            {ok, stream_read};
-        {ok, Value, Next} ->
-            io:format("~w~n", [Value]),
-            async_print_stream(Next);
-         Any ->
-            io:format("~w~n", [Any])
-    end.
 
 %% Internal functions
 

--- a/src/derflow_vnode.erl
+++ b/src/derflow_vnode.erl
@@ -6,9 +6,7 @@
 -define(N, 1).
 -define(VNODE_MASTER, derflow_vnode_master).
 
--export([async_bind/2,
-         async_bind/3,
-         bind/2,
+-export([bind/2,
          bind/3,
          read/1,
          touch/1,
@@ -48,18 +46,6 @@
              bounded = false}).
 
 %% Extrenal API
-
-async_bind(Id, Value) ->
-    [{IndexNode, _Type}] = generate_preference_list(?N, Id),
-    riak_core_vnode_master:sync_spawn_command(IndexNode,
-                                              {async_bind, Id, Value},
-                                              ?VNODE_MASTER).
-
-async_bind(Id, Function, Args) ->
-    [{IndexNode, _Type}] = generate_preference_list(?N, Id),
-    riak_core_vnode_master:sync_spawn_command(IndexNode,
-                                              {async_bind, Id, Function, Args},
-                                              ?VNODE_MASTER).
 
 bind(Id, Value) ->
     [{IndexNode, _Type}] = generate_preference_list(?N, Id),
@@ -156,38 +142,6 @@ handle_command(get_new_id, _From,
 handle_command({declare, Id}, _From, State=#state{table=Table}) ->
     true = ets:insert(Table, {Id, #dv{value=undefined}}),
     {reply, {ok, Id}, State};
-
-handle_command({async_bind, Id, F, Arg}, _From,
-               State=#state{partition=Partition, table=Table}) ->
-    [{_Key, V}] = ets:lookup(Table, Id),
-    NextKey0 = V#dv.next,
-    if
-        NextKey0 == undefined ->
-            Next = State#state.clock + 1,
-            NextKey = {Next, Partition},
-            declare(NextKey);
-        true ->
-            {Next, _} = NextKey0,
-            NextKey = NextKey0
-        end,
-    spawn(derflow_vnode, execute_and_put, [F, Arg, NextKey, Id, Table]),
-    {reply, {ok, NextKey}, State#state{clock=Next}};
-
-handle_command({async_bind, Id, Value}, _From,
-               State=#state{partition=Partition, table=Table}) ->
-    [{_Key,V}] = ets:lookup(Table, Id),
-    NextKey0 = V#dv.next,
-    if
-        NextKey0 == undefined ->
-            Next = State#state.clock + 1,
-            NextKey={Next, Partition},
-            declare(NextKey);
-        true ->
-            {Next, _} = NextKey0,
-            NextKey = NextKey0
-    end,
-    spawn(derflow_vnode, put, [Value, NextKey, Id, Table]),
-    {reply, {ok, NextKey}, State#state{clock=Next}};
 
 handle_command({bind, Id, Fun, Arg}, _From,
                State=#state{partition=Partition, table=Table}) ->


### PR DESCRIPTION
Given there is no real use for the async operators right now, and we
have no semantics for them, remove them temporarily.
