### PR TITLE
Add naive support for parametrized CRDTS.

### DIFF
--- a/riak_test/lasp_leaderboard_test.erl
+++ b/riak_test/lasp_leaderboard_test.erl
@@ -65,7 +65,7 @@ test() ->
     Self = self(),
 
     %% Create a leaderboard datatype.
-    {ok, LeaderboardId} = lasp:declare(lasp_top_k_var),
+    {ok, LeaderboardId} = lasp:declare({lasp_top_k_var, [2]}),
 
     %% Read the leaderboard's current value.
     {ok, {_, _, _, Leaderboard}} = lasp:read(LeaderboardId, undefined),
@@ -87,7 +87,7 @@ test() ->
     Final = orddict:to_list(lasp_top_k_var:value(FinalLeaderboard)),
 
     %% Assert we got the right score.
-    [{_, FinalResult}] = Final,
+    [{_, FinalResult}, {_, _}] = Final,
 
     io:format("Final Leaderboard: ~p", [Final]),
 

--- a/src/lasp_dt.erl
+++ b/src/lasp_dt.erl
@@ -1,0 +1,27 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015 Christopher Meiklejohn.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(lasp_dt).
+-author("Christopher Meiklejohn <christopher.meiklejohn@gmail.com>").
+
+-include("lasp.hrl").
+
+%% Unified interface for allowing parameterized CRDTs.
+-callback new([term()]) -> term().

--- a/src/lasp_lattice.erl
+++ b/src/lasp_lattice.erl
@@ -49,6 +49,8 @@
 %%      `Value' and `Threshold' both should be an instance of one of the
 %%      `type()'s and not a pure value.
 %%
+threshold_met({Type, _}, Value, Current) ->
+    threshold_met(Type, Value, Current);
 threshold_met(lasp_ivar, undefined, {strict, undefined}) ->
     false;
 threshold_met(lasp_ivar, undefined, undefined) ->
@@ -100,6 +102,8 @@ threshold_met(riak_dt_gcounter, Value, Threshold) ->
 %%      Given a particular type and two instances of that type,
 %%      determine if `Current' is an inflation of `Previous'.
 %%
+is_inflation({Type, _}, Previous, Current) ->
+    is_inflation(Type, Previous, Current);
 is_inflation(Type, Previous, Current) ->
     is_lattice_inflation(Type, Previous, Current).
 
@@ -108,6 +112,8 @@ is_inflation(Type, Previous, Current) ->
 %%      Given a particular type and two instances of that type,
 %%      determine if `Current' is a strict inflation of `Previous'.
 %%
+is_strict_inflation({Type, _}, Previous, Current) ->
+    is_strict_inflation(Type, Previous, Current);
 is_strict_inflation(Type, Previous, Current) ->
     is_lattice_strict_inflation(Type, Previous, Current).
 

--- a/src/lasp_top_k_var.erl
+++ b/src/lasp_top_k_var.erl
@@ -24,13 +24,16 @@
 %%            "A Study of CRDTs that do computations"
 %%            http://dl.acm.org/citation.cfm?id=2745948
 %%
+
 -module(lasp_top_k_var).
 -author("Christopher Meiklejohn <christopher.meiklejohn@gmail.com>").
 
 -include("lasp.hrl").
 
 -behaviour(riak_dt).
+-behaviour(lasp_dt).
 
+-export([new/1]).
 -export([new/0,
          value/1,
          update/3,
@@ -64,14 +67,17 @@
 %% @doc Return a new top-k variable; assumes with no arguments top-1.
 -spec new() -> top_k_var().
 new() ->
-    {1, orddict:new()}.
+    new([1]).
+
+%% @doc Return a new top-k variable.
+-spec new([non_neg_integer()]) -> top_k_var().
+new([K]) ->
+    {K, orddict:new()}.
 
 %% @doc Update the CRDT with a given key/value pair.
 -spec update(top_k_var_op(), actor(), top_k_var()) -> {ok, top_k_var()}.
 update({set, Key, Value}, _Actor, {K, Var0}) ->
-    UpdateFun = fun(Value0) ->
-                        max(Value, Value0)
-                end,
+    UpdateFun = fun(Value0) -> max(Value, Value0) end,
     Var = orddict:update(Key, UpdateFun, Value, Var0),
     {ok, enforce_k({K, Var})}.
 

--- a/src/lasp_type.erl
+++ b/src/lasp_type.erl
@@ -1,0 +1,51 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015 Christopher Meiklejohn.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(lasp_type).
+-author("Christopher Meiklejohn <christopher.meiklejohn@gmail.com>").
+
+-export([new/1, update/4, merge/3]).
+
+%% @doc Initialize a new variable for a given type.
+new(Type) ->
+    case Type of
+        {T, Args} ->
+            T:new(Args);
+        T ->
+            T:new()
+    end.
+
+%% @doc Use the proper type for performing an update.
+update(Type, Operation, Actor, Value) ->
+    case Type of
+        {T, _Args} ->
+            T:update(Operation, Actor, Value);
+        T ->
+            T:update(Operation, Actor, Value)
+    end.
+
+%% @doc Call the correct merge function for a given type.
+merge(Type, Value0, Value) ->
+    case Type of
+        {T, _Args} ->
+            T:merge(Value0, Value);
+        T ->
+            T:merge(Value0, Value)
+    end.


### PR DESCRIPTION
Add naive support for parametrized CRDTS, such as the top-K CRDT,
where a top-1 CRDT should differ from a top-2 CRDT.

Model types as tuples, that take the arguments used to initialize it:
for example, use the argument of a top-K CRDT to be the K value for that
given type.