### PR TITLE
Garbage collection for the delta-based anti-entropy strategy

### DIFF
--- a/include/lasp.hrl
+++ b/include/lasp.hrl
@@ -48,6 +48,10 @@
             {error, timeout}
         end).
 
+%% @doc Garbage collection will happen after the certain number
+%%      (MAX_GC_COUNTER) of times of exchanges.
+-define(MAX_GC_COUNTER, 7).
+
 %% General types.
 -type file() :: iolist().
 -type registration() :: preflist | global.

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -914,7 +914,7 @@ increment_counter(Counter) ->
 
 %% @private
 store_delta(Type, Counter, Delta, DeltaMap0) ->
-    MaxDeltaSlots = application:get_env(lasp, delta_mode_max_slots, 10),
+    MaxDeltaSlots = mochiglobal:get(delta_mode_max_slots, 10),
     %% Check the space of the DeltaMap
     case orddict:size(DeltaMap0) < MaxDeltaSlots of
         true ->

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -356,7 +356,7 @@ bind(Id, {delta, Value}, MetadataFun, Store) ->
                 {ok, SW} = reply_to_all(WT, [], {ok, {Id, Type, Metadata, Merged}}),
                 case lasp_lattice:is_strict_inflation(Type, Value0, Merged) of
                     true ->
-                        DeltaMap = orddict:store(Counter0, Value, DeltaMap0),
+                        DeltaMap = store_delta(Type, Counter0, Value, DeltaMap0),
                         NewObject = #dv{type=Type, metadata=Metadata, value=Merged,
                                         waiting_threads=SW,
                                         delta_counter=increment_counter(Counter0),
@@ -877,12 +877,12 @@ receive_delta(Store, {delta_ack, Id, From, Counter}) ->
     case do(get, [Store, Id]) of
         {ok, #dv{delta_ack_map=AckMap0}=Object} ->
             OldAck = case orddict:find(From, AckMap0) of
-                         {ok, Ack0} ->
+                         {ok, {Ack0, _GCed}} ->
                              Ack0;
                          error ->
                              0
                      end,
-            AckMap = orddict:store(From, max(OldAck, Counter), AckMap0),
+            AckMap = orddict:store(From, {max(OldAck, Counter), false}, AckMap0),
             do(put, [Store, Id, Object#dv{delta_ack_map=AckMap}]);
         _ ->
             error
@@ -911,6 +911,34 @@ write(Type, Value, Key, Store) ->
 %% @private
 increment_counter(Counter) ->
     Counter + 1.
+
+%% @private
+store_delta(Type, Counter, Delta, DeltaMap0) ->
+    MaxDeltaSlots = application:get_env(lasp, delta_mode_max_slots, 10),
+    %% Check the space of the DeltaMap
+    case orddict:size(DeltaMap0) < MaxDeltaSlots of
+        true ->
+            %% Store a new delta.
+            orddict:store(Counter, Delta, DeltaMap0);
+        false ->
+            DeltaCounterList = orddict:fetch_keys(DeltaMap0),
+            %% Find the minimum counter & its delta.
+            MinCounter0 = lists:nth(1, DeltaCounterList),
+            MinCounterDelta0 = orddict:fetch(MinCounter0, DeltaMap0),
+            %% Find the 2nd minimum counter & its delta.
+            MinCounter1 = lists:nth(2, DeltaCounterList),
+            MinCounterDelta1 = orddict:fetch(MinCounter1, DeltaMap0),
+            %% Merge them.
+            Merged = lasp_type:merge(Type,
+                                     MinCounterDelta0,
+                                     MinCounterDelta1),
+            %% Store the merged delta (minimum + 2nd minimum).
+            DeltaMap1 = orddict:store(MinCounter0, Merged, DeltaMap0),
+            %% Remove the 2nd minimum delta.
+            DeltaMap2 = orddict:erase(MinCounter1, DeltaMap1),
+            %% Store a new delta.
+            orddict:store(Counter, Delta, DeltaMap2)
+    end.
 
 -ifdef(TEST).
 

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -921,13 +921,9 @@ store_delta(Type, Counter, Delta, DeltaMap0) ->
             %% Store a new delta.
             orddict:store(Counter, Delta, DeltaMap0);
         false ->
-            DeltaCounterList = orddict:fetch_keys(DeltaMap0),
-            %% Find the minimum counter & its delta.
-            MinCounter0 = lists:nth(1, DeltaCounterList),
-            MinCounterDelta0 = orddict:fetch(MinCounter0, DeltaMap0),
-            %% Find the 2nd minimum counter & its delta.
-            MinCounter1 = lists:nth(2, DeltaCounterList),
-            MinCounterDelta1 = orddict:fetch(MinCounter1, DeltaMap0),
+            %% Find the minimum and 2nd minimum counters & those deltas.
+            [{MinCounter0, MinCounterDelta0}, {MinCounter1, MinCounterDelta1} | _Rest] =
+                orddict:to_list(DeltaMap0),
             %% Merge them.
             Merged = lasp_type:merge(Type,
                                      MinCounterDelta0,

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -742,8 +742,6 @@ handle_cast({delta_send, From, {Id, Type, _Metadata, Deltas}, Counter},
                                           {Id, Type, _Metadata, Deltas},
                                           ?CLOCK_INCR,
                                           ?CLOCK_INIT}),
-    lager:info("Send Delta({delta_ack}): To: ~p, Counter: ~p",
-                                          [From, Counter]),
     gen_server:cast({?MODULE, From}, {delta_ack, node(), Id, Counter}),
     {noreply, State};
 

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -189,7 +189,7 @@ exchange(Peer) ->
         true ->
             %% Anti-entropy mechanism for causal consistency of delta-CRDT.
             {ok, Pid, GC_Counter} = gen_server:call(?MODULE, {exchange, Peer}, infinity),
-            MaxGCCounter = application:get_env(lasp, delta_mode_max_gc_counter, 7),
+            MaxGCCounter = mochiglobal:get(delta_mode_max_gc_counter, 7),
             case GC_Counter == MaxGCCounter of
                 true ->
                     gen_server:call(?MODULE, delta_gc, infinity);

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -742,6 +742,8 @@ handle_cast({delta_send, From, {Id, Type, _Metadata, Deltas}, Counter},
                                           {Id, Type, _Metadata, Deltas},
                                           ?CLOCK_INCR,
                                           ?CLOCK_INIT}),
+    lager:info("Send Delta({delta_ack}): To: ~p, Counter: ~p",
+                                          [From, Counter]),
     gen_server:cast({?MODULE, From}, {delta_ack, node(), Id, Counter}),
     {noreply, State};
 

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -69,7 +69,8 @@
 %% State record.
 -record(state, {store :: store(),
                 actor :: binary(),
-                counter :: non_neg_integer()}).
+                counter :: non_neg_integer(),
+                gc_counter :: non_neg_integer()}).
 
 %% Broadcast record.
 -record(broadcast, {id :: id(),
@@ -187,7 +188,14 @@ exchange(Peer) ->
     case mochiglobal:get(delta_mode, false) of
         true ->
             %% Anti-entropy mechanism for causal consistency of delta-CRDT.
-            gen_server:call(?MODULE, {exchange, Peer}, infinity);
+            {ok, Pid, GC_Counter} = gen_server:call(?MODULE, {exchange, Peer}, infinity),
+            MaxGCCounter = application:get_env(lasp, delta_mode_max_gc_counter, 7),
+            case GC_Counter == MaxGCCounter of
+                true ->
+                    gen_server:call(?MODULE, delta_gc, infinity);
+                false ->
+                    {ok, Pid}
+            end;
         false ->
             %% Naive anti-entropy mechanism; re-broadcast all messages.
             gen_server:call(?MODULE, exchange, infinity)
@@ -417,6 +425,7 @@ wait_needed(Id, Threshold) ->
 init([]) ->
     {ok, Actor} = lasp_unique:unique(),
     Counter = 0,
+    GC_Counter = 0,
     Identifier = node(),
     {ok, Store} = case ?CORE:start(Identifier) of
         {ok, Pid} ->
@@ -427,7 +436,7 @@ init([]) ->
             lager:error("Failed to initialize backend: ~p", [Reason]),
             {error, Reason}
     end,
-    {ok, #state{actor=Actor, counter=Counter, store=Store}}.
+    {ok, #state{actor=Actor, counter=Counter, store=Store, gc_counter=GC_Counter}}.
 
 %% @private
 -spec handle_call(term(), {pid(), term()}, #state{}) ->
@@ -596,33 +605,31 @@ handle_call({is_stale, Id, TheirClock}, _From, #state{store=Store}=State) ->
 
 %% Anti-entropy mechanism for causal consistency of delta-CRDT;
 %% periodically ship delta-interval or entire state.
-handle_call({exchange, Peer}, _From, #state{store=Store}=State) ->
+handle_call({exchange, Peer}, _From, #state{store=Store, gc_counter=GC_Counter}=State) ->
     Function = fun({Id, #dv{value=Value, type=Type, metadata=Metadata,
                             delta_counter=Counter, delta_map=DeltaMap,
                             delta_ack_map=AckMap}},
                    Acc0) ->
                        Ack = case orddict:find(Peer, AckMap) of
-                                 {ok, Ack0} ->
+                                 {ok, {Ack0, _GCed}} ->
                                      Ack0;
                                  error ->
                                      0
                              end,
-                       Causality = case orddict:fetch_keys(DeltaMap) of
-                                       [] ->
-                                           0 > Ack;
-                                       Keys ->
-                                           lists:min(Keys) > Ack
-                                   end,
-                       Deltas = case orddict:is_empty(DeltaMap) or Causality of
-                                    true ->
-                                        Value;
-                                    false ->
-                                        collect_deltas(Type, DeltaMap, Ack, Counter)
-                                end,
                        case Ack < Counter of
                            true ->
-                               lager:info("Send Delta({delta_send}): To: ~p, Counter: ~p",
-                                          [Peer, Counter]),
+                               Causality = case orddict:fetch_keys(DeltaMap) of
+                                               [] ->
+                                                   true;
+                                               Keys ->
+                                                   lists:min(Keys) > Ack
+                                           end,
+                               Deltas = case Causality of
+                                            true ->
+                                                Value;
+                                            false ->
+                                                collect_deltas(Type, DeltaMap, Ack, Counter)
+                                        end,
                                gen_server:cast({?MODULE, Peer},
                                                {delta_send,
                                                 node(),
@@ -630,11 +637,11 @@ handle_call({exchange, Peer}, _From, #state{store=Store}=State) ->
                                                 Counter}),
                                [{ok, Id}|Acc0];
                            false ->
-                               [Acc0]
+                               Acc0
                        end
                end,
     Pid = spawn(fun() -> do(fold, [Store, Function, []]) end),
-    {reply, {ok, Pid}, State};
+    {reply, {ok, Pid, GC_Counter}, State#state{gc_counter=increment_counter(GC_Counter)}};
 
 %% Naive anti-entropy mechanism; periodically re-broadcast all messages.
 handle_call(exchange, _From, #state{store=Store}=State) ->
@@ -651,6 +658,78 @@ handle_call(exchange, _From, #state{store=Store}=State) ->
     Pid = spawn(fun() -> do(fold, [Store, Function, []]) end),
     {reply, {ok, Pid}, State};
 
+handle_call(delta_gc, _From, #state{store=Store}=State) ->
+    Function =
+        fun({Id, #dv{delta_map=DeltaMap0, delta_ack_map=AckMap0,
+                     delta_counter=Counter}=_Object},
+            Acc0) ->
+                case orddict:is_empty(DeltaMap0) of
+                    true ->
+                        Acc0;
+                    false ->
+                        %% Remove disconnected or slow node() entries from the AckMap.
+                        %% disconnected or slow: seen the previous GC & no change
+                        RemovedAckMap0 =
+                            orddict:filter(fun(_Node, {Ack, GCed}) ->
+                                                   (GCed == false) or (Ack == Counter)
+                                           end, AckMap0),
+                        case orddict:size(RemovedAckMap0) of
+                            0 ->
+                                Acc0;
+                            _ ->
+                                %% Mark remained entries as seen this GC.
+                                RemovedAckMap =
+                                    orddict:fold(
+                                      fun(Node, {Ack, _GCed}, RemovedAckMap1) ->
+                                              orddict:store(Node, {Ack, true},
+                                                            RemovedAckMap1)
+                                      end, orddict:new(), RemovedAckMap0),
+                                %% Collect garbage deltas.
+                                MinAck =
+                                    lists:min([Ack || {_Node, {Ack, _GCed}} <- RemovedAckMap]),
+                                %% size() should be bigger than 0.
+                                MinAck1 =
+                                    case orddict:size(DeltaMap0) of
+                                        1 ->
+                                            MinAck;
+                                        _ ->
+                                            Counters = orddict:fetch_keys(DeltaMap0),
+                                            NotCollectable =
+                                                (MinAck > lists:nth(1, Counters)) and
+                                                    (MinAck < lists:nth(2, Counters)),
+                                            case NotCollectable of
+                                                true ->
+                                                    lists:nth(1, Counters);
+                                                false ->
+                                                    MinAck
+                                            end
+                                    end,
+                                DeltaMap = orddict:filter(fun(Counter0, _Delta) ->
+                                                                  Counter0 >= MinAck1
+                                                          end, DeltaMap0),
+                                [{ok, Id, DeltaMap, RemovedAckMap}|Acc0]
+                        end
+                end
+        end,
+    Pid = spawn(
+            fun() ->
+                    {ok, Results} = do(fold, [Store, Function, []]),
+                    lists:foreach(
+                      fun({ok, Id, DeltaMap, RemovedAckMap}) ->
+                              case do(get, [Store, Id]) of
+                                  {ok, Object} ->
+                                      _ = do(put,
+                                             [Store, Id,
+                                              Object#dv{delta_map=DeltaMap,
+                                                        delta_ack_map=RemovedAckMap}]),
+                                      ok;
+                                  _ ->
+                                      ok
+                              end
+                      end, Results)
+            end),
+    {reply, {ok, Pid}, State#state{gc_counter=0}};
+
 %% @private
 handle_call(Msg, _From, State) ->
     lager:warning("Unhandled messages: ~p", [Msg]),
@@ -659,20 +738,14 @@ handle_call(Msg, _From, State) ->
 -spec handle_cast(term(), #state{}) -> {noreply, #state{}}.
 handle_cast({delta_send, From, {Id, Type, _Metadata, Deltas}, Counter},
             #state{store=Store, actor=Actor}=State) ->
-    lager:info("Receive Delta({delta_send}): From: ~p, Counter: ~p",
-               [From, Counter]),
     _Result = ?CORE:receive_delta(Store, {delta_send,
                                           {Id, Type, _Metadata, Deltas},
                                           ?CLOCK_INCR,
                                           ?CLOCK_INIT}),
-    lager:info("Send Delta({delta_ack}): To: ~p, Counter: ~p",
-                                          [From, Counter]),
     gen_server:cast({?MODULE, From}, {delta_ack, node(), Id, Counter}),
     {noreply, State};
 
 handle_cast({delta_ack, From, Id, Counter}, #state{store=Store}=State) ->
-    lager:info("Receive Delta({delta_ack}): From: ~p, Counter: ~p",
-               [From, Counter]),
     _Result = ?CORE:receive_delta(Store, {delta_ack,
                                           Id,
                                           From,
@@ -749,13 +822,20 @@ increment_counter(Counter) ->
     Counter + 1.
 
 %% @private
-collect_deltas(Type, DeltaMap, Min, Max) ->
+collect_deltas(Type, DeltaMap, Min0, Max) ->
+    Counters = orddict:fetch_keys(DeltaMap),
+    Min1 = case lists:member(Min0, Counters) of
+               true ->
+                   Min0;
+               false ->
+                   lists:min(Counters)
+           end,
     SmallDeltaMap = orddict:filter(fun(Counter, _Delta) ->
-                                           (Counter >= Min) or (Counter < Max)
+                                           (Counter >= Min1) or (Counter < Max)
                                    end, DeltaMap),
     Deltas = orddict:fold(fun(_Counter, Delta, Deltas0) ->
-                                  Type:merge(Deltas0, Delta)
-                          end, Type:new(), SmallDeltaMap),
+                                  lasp_type:merge(Type, Deltas0, Delta)
+                          end, lasp_type:new(Type), SmallDeltaMap),
     {delta, Deltas}.
 
 -ifdef(TEST).

--- a/src/lasp_sup.erl
+++ b/src/lasp_sup.erl
@@ -150,7 +150,7 @@ init(_Args) ->
     MaxDeltaSlots = application:get_env(?APP, delta_mode_max_slots, 10),
     mochiglobal:put(delta_mode_max_slots, MaxDeltaSlots),
 
-    MaxGCCounter = application:get_env(?APP, delta_mode_max_gc_counter, 7),
+    MaxGCCounter = application:get_env(?APP, delta_mode_max_gc_counter, ?MAX_GC_COUNTER),
     mochiglobal:put(delta_mode_max_gc_counter, MaxGCCounter),
 
     mochiglobal:put(instrumentation, InstrEnabled),

--- a/src/lasp_sup.erl
+++ b/src/lasp_sup.erl
@@ -147,6 +147,12 @@ init(_Args) ->
                             lasp_plumtree_broadcast_distribution_backend),
     mochiglobal:put(distribution_backend, DistributionBackend),
 
+    MaxDeltaSlots = application:get_env(?APP, delta_mode_max_slots, 10),
+    mochiglobal:put(delta_mode_max_slots, MaxDeltaSlots),
+
+    MaxGCCounter = application:get_env(?APP, delta_mode_max_gc_counter, 7),
+    mochiglobal:put(delta_mode_max_gc_counter, MaxGCCounter),
+
     mochiglobal:put(instrumentation, InstrEnabled),
 
     {ok, {{one_for_one, 5, 10}, Children}}.


### PR DESCRIPTION
1. The delta_map has the limitation of the number of slots for storing deltas (`delta_mode_max_slots`).

2. When the slots are full, the first slot becomes an accumulator to store multiple deltas instead of deleting one of deltas (in order to avoid sending the entire state due to deleted deltas).

3. The delta_ack_map stores an extra boolean to check whether an 'ack' existed when the previous gc happened. With this boolean, we can check nodes are disconnected or slow and those nodes will be deleted during the next gc. This allows the deltas (garbage) to be collected after the disconnection of nodes.

4. The gc will happen after the certain number (`delta_mode_max_gc_counter`) of times of exchanges.