### PR TITLE
Dependency graph

### DIFF
--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -737,10 +737,11 @@ stream(Id, Function, Store) ->
 %%      stream can result in observable nondeterminism.
 %%
 stream(Id, Function, _Store, ReadFun) ->
-    Fun = fun({_, T, _, V}) ->
-            Function(lasp_type:query(T, V))
+    TransFun = fun({_, T, _, V}) ->
+        Function(lasp_type:query(T, V))
     end,
-    lasp_process:start_link([[{Id, ReadFun}], Fun]).
+    WriteFun = fun(_, X) -> X end,
+    lasp_process:start_dag_link([{Id, ReadFun}], TransFun, {undefined, WriteFun}).
 
 %% @doc Callback wait_needed function for lasp_vnode, where we
 %%      change the reply and blocking replies.

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -305,7 +305,7 @@ query(Id, Store) ->
 %%
 -spec bind_to(id(), id(), store()) -> {ok, pid()}.
 bind_to(AccId, Id, Store) ->
-    bind_to(AccId, Id, Store, ?BIND, ?READ).
+    bind_to(AccId, Id, Store, ?WRITE, ?READ).
 
 %% @doc Spawn a function.
 %%
@@ -560,10 +560,8 @@ bind_to(AccId, Id, Store, BindFun) ->
     bind_to(AccId, Id, Store, BindFun, ?READ).
 
 bind_to(AccId, Id, Store, BindFun, ReadFun) ->
-    Fun = fun({_, _, _, V}) ->
-        {ok, _} = BindFun(AccId, V, Store)
-    end,
-    lasp_process:start_link([[{Id, ReadFun}], Fun]).
+    TransFun = fun({_, _, _, V}) -> V end,
+    lasp_process:start_dag_link([{Id, ReadFun}], TransFun, {AccId, BindFun(Store)}).
 
 %% @doc Fold values from one lattice into another.
 %%

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -77,6 +77,12 @@
                 ?MODULE:bind(_AccId, AccValue, _Store)
               end).
 
+-define(WRITE, fun(_Store) ->
+                 fun(_AccId, _AccValue) ->
+                   {ok, _} = ?MODULE:bind(_AccId, _AccValue, _Store)
+                 end
+               end).
+
 -define(READ, fun(_Id, _Threshold) ->
                 ?MODULE:read(_Id, _Threshold, Store)
               end).

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -100,7 +100,7 @@ start(Identifier) ->
 %%
 -spec filter(id(), function(), id(), store()) -> {ok, pid()}.
 filter(Id, Function, AccId, Store) ->
-    filter(Id, Function, AccId, Store, ?BIND, ?READ).
+    filter(Id, Function, AccId, Store, ?WRITE, ?READ).
 
 %% @doc Fold values from one lattice into another.
 %%
@@ -722,11 +722,10 @@ map(Id, Function, AccId, Store, BindFun, ReadFun) ->
 -spec filter(id(), function(), id(), store(), function(), function()) ->
     {ok, pid()}.
 filter(Id, Function, AccId, Store, BindFun, ReadFun) ->
-    Fun = fun({_, _, _, V}) ->
-            AccValue = state_orset_ext:filter(Function, V),
-            {ok, _} = BindFun(AccId, AccValue, Store)
+    TransFun = fun({_, _, _, V}) ->
+        state_orset_ext:filter(Function, V)
     end,
-    lasp_process:start_link([[{Id, ReadFun}], Fun]).
+    lasp_process:start_dag_link([{Id, ReadFun}], TransFun, {AccId, BindFun(Store)}).
 
 %% @doc Stream values out of the Lasp system; using the values from this
 %%      stream can result in observable nondeterminism.

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -561,7 +561,7 @@ bind_to(AccId, Id, Store, BindFun) ->
 
 bind_to(AccId, Id, Store, BindFun, ReadFun) ->
     TransFun = fun({_, _, _, V}) -> V end,
-    lasp_process:start_dag_link([{Id, ReadFun}], TransFun, {AccId, BindFun(Store)}).
+    lasp_process:start_dag_link([[{Id, ReadFun}], TransFun, {AccId, BindFun(Store)}]).
 
 %% @doc Fold values from one lattice into another.
 %%
@@ -629,8 +629,8 @@ product(Left, Right, AccId, Store, BindFun, ReadLeftFun, ReadRightFun) ->
                     state_orset_ext:product(LValue, RValue)
             end
     end,
-    lasp_process:start_dag_link([{Left, ReadLeftFun}, {Right, ReadRightFun}],
-                                TransFun, {AccId, BindFun(Store)}).
+    lasp_process:start_dag_link([[{Left, ReadLeftFun}, {Right, ReadRightFun}],
+                                TransFun, {AccId, BindFun(Store)}]).
 
 %% @doc Compute the intersection of two sets.
 %%
@@ -654,8 +654,8 @@ intersection(Left, Right, AccId, Store, BindFun, ReadLeftFun, ReadRightFun) ->
                     state_orset_ext:intersect(LValue, RValue)
             end
     end,
-    lasp_process:start_dag_link([{Left, ReadLeftFun}, {Right, ReadRightFun}],
-                                TransFun, {AccId, BindFun(Store)}).
+    lasp_process:start_dag_link([[{Left, ReadLeftFun}, {Right, ReadRightFun}],
+                                TransFun, {AccId, BindFun(Store)}]).
 
 %% @doc Compute the union of two sets.
 %%
@@ -679,8 +679,8 @@ union(Left, Right, AccId, Store, BindFun, ReadLeftFun, ReadRightFun) ->
                     state_orset_ext:union(LValue, RValue)
             end
     end,
-    lasp_process:start_dag_link([{Left, ReadLeftFun}, {Right, ReadRightFun}],
-                                TransFun, {AccId, BindFun(Store)}).
+    lasp_process:start_dag_link([[{Left, ReadLeftFun}, {Right, ReadRightFun}],
+                                TransFun, {AccId, BindFun(Store)}]).
 
 %% @doc Lap values from one lattice into another.
 %%
@@ -704,7 +704,7 @@ map(Id, Function, AccId, Store, BindFun, ReadFun) ->
             AccValue = state_orset_ext:map(Function, V),
             {delta, AccValue}
     end,
-    lasp_process:start_dag_link([{Id, ReadFun}], TransFun, {AccId, BindFun(Store)}).
+    lasp_process:start_dag_link([[{Id, ReadFun}], TransFun, {AccId, BindFun(Store)}]).
 
 %% @doc Filter values from one lattice into another.
 %%
@@ -722,7 +722,7 @@ filter(Id, Function, AccId, Store, BindFun, ReadFun) ->
     TransFun = fun({_, _, _, V}) ->
         state_orset_ext:filter(Function, V)
     end,
-    lasp_process:start_dag_link([{Id, ReadFun}], TransFun, {AccId, BindFun(Store)}).
+    lasp_process:start_dag_link([[{Id, ReadFun}], TransFun, {AccId, BindFun(Store)}]).
 
 %% @doc Stream values out of the Lasp system; using the values from this
 %%      stream can result in observable nondeterminism.
@@ -738,7 +738,7 @@ stream(Id, Function, _Store, ReadFun) ->
         Function(lasp_type:query(T, V))
     end,
     WriteFun = fun(_, X) -> X end,
-    lasp_process:start_dag_link([{Id, ReadFun}], TransFun, {undefined, WriteFun}).
+    lasp_process:start_dag_link([[{Id, ReadFun}], TransFun, {ignore, WriteFun}]).
 
 %% @doc Callback wait_needed function for lasp_vnode, where we
 %%      change the reply and blocking replies.

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -573,6 +573,8 @@ bind_to(AccId, Id, Store, BindFun, ReadFun) ->
 %%      function for the `BindFun', which is responsible for binding the
 %%      result, for instance, when it's located in another table.
 %%
+%%      @todo track in dag
+%%
 -spec fold(id(), function(), id(), store(), function(), function()) ->
     {ok, pid()}.
 fold(Id, Function, AccId, Store, BindFun, ReadFun) ->

--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -111,7 +111,7 @@ handle_call({is_loop, From, To}, _From, #state{dag=Dag}=State) ->
 
 %% @doc For all V in Src, create an edge from V to Dst labelled with Pid.
 handle_call({add_edges, Src, Dst, Pid}, _From, #state{dag=Dag}=State) ->
-    %% @todo: Add metadata and duplicate checking.
+    %% @todo Add metadata and duplicate checking.
     Status = [digraph:add_edge(Dag, V, Dst, Pid) || V <- Src],
     R = case lists:any(fun is_graph_error/1, Status) of
         false -> ok;

--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -10,6 +10,14 @@
          add_vertex/1,
          add_vertices/1]).
 
+%% Test
+-export([n_vertices/0,
+         n_edges/0,
+         out_degree/1,
+         in_degree/1,
+         out_edges/1,
+         in_edges/1]).
+
 %% gen_server callbacks
 -export([init/1,
          handle_call/3,
@@ -57,6 +65,24 @@ is_loop(Src, Dst) ->
 add_edges(Src, Dst, Pid) ->
     gen_server:call(?MODULE, {add_edges, Src, Dst, Pid}, infinity).
 
+n_vertices() ->
+    gen_server:call(?MODULE, n_vertices, infinity).
+
+n_edges() ->
+    gen_server:call(?MODULE, n_edges, infinity).
+
+in_degree(V) ->
+    gen_server:call(?MODULE, {in_degree, V}, infinity).
+
+out_degree(V) ->
+    gen_server:call(?MODULE, {out_degree, V}, infinity).
+
+out_edges(V) ->
+    gen_server:call(?MODULE, {out_edges, V}, infinity).
+
+in_edges(V) ->
+    gen_server:call(?MODULE, {in_edges, V}, infinity).
+
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
@@ -68,6 +94,26 @@ init([]) ->
 %% @private
 -spec handle_call(term(), {pid(), term()}, #state{}) ->
     {reply, term(), #state{}}.
+
+handle_call(n_vertices, _From, #state{dag=Dag}=State) ->
+    {reply, {ok, digraph:no_vertices(Dag)}, State};
+
+handle_call(n_edges, _From, #state{dag=Dag}=State) ->
+    {reply, {ok, digraph:no_edges(Dag)}, State};
+
+handle_call({in_degree, V}, _From, #state{dag=Dag}=State) ->
+    {reply, {ok, digraph:in_degree(Dag, V)}, State};
+
+handle_call({out_degree, V}, _From, #state{dag=Dag}=State) ->
+    {reply, {ok, digraph:out_degree(Dag, V)}, State};
+
+handle_call({out_edges, V}, _From, #state{dag=Dag}=State) ->
+    Edges = [digraph:edge(Dag, E) || E <- digraph:out_edges(Dag, V)],
+    {reply, {ok, Edges}, State};
+
+handle_call({in_edges, V}, _From, #state{dag=Dag}=State) ->
+    Edges = [digraph:edge(Dag, E) || E <- digraph:in_edges(Dag, V)],
+    {reply, {ok, Edges}, State};
 
 handle_call({add_vertex, V}, _From, #state{dag=Dag}=State) ->
     digraph:add_vertex(Dag, V),

--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -1,0 +1,156 @@
+-module(lasp_dependence_dag).
+
+-include("lasp.hrl").
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0,
+         is_loop/2,
+         add_edges/3,
+         add_vertex/1,
+         add_vertices/1]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+%%%===================================================================
+%%% Type definitions
+%%%===================================================================
+
+-record(state, {dag :: digraph:graph()}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec add_vertex(id()) -> ok.
+add_vertex(V) ->
+    gen_server:call(?MODULE, {add_vertex, V}, infinity).
+
+-spec add_vertices(list(id())) -> ok.
+add_vertices([]) ->
+    ok;
+
+add_vertices(Vs) ->
+    gen_server:call(?MODULE, {add_vertices, Vs}, infinity).
+
+%% @doc Check if linking the given vertices will form a loop.
+-spec is_loop(list(id()), id()) -> boolean().
+is_loop(Src, Dst) ->
+    gen_server:call(?MODULE, {is_loop, Src, Dst}, infinity).
+
+%% @doc For all V in Src, create an edge from V to Dst labelled with Pid.
+%%
+%%      Returns error if it couldn't create some of the edges,
+%%      either because it formed a loop, or because some of the
+%%      vertices weren't in the graph.
+%%
+-spec add_edges(list(id()), id(), pid()) -> ok | error.
+add_edges(Src, Dst, Pid) ->
+    gen_server:call(?MODULE, {add_edges, Src, Dst, Pid}, infinity).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%% @doc Initialize state.
+init([]) ->
+    {ok, #state{dag=digraph:new([acyclic])}}.
+
+%% @private
+-spec handle_call(term(), {pid(), term()}, #state{}) ->
+    {reply, term(), #state{}}.
+
+handle_call({add_vertex, V}, _From, #state{dag=Dag}=State) ->
+    digraph:add_vertex(Dag, V),
+    {reply, ok, State};
+
+handle_call({add_vertices, Vs}, _From, #state{dag=Dag}=State) ->
+    [digraph:add_vertex(Dag, V) || V <- Vs],
+    {reply, ok, State};
+
+%% @doc Check if linking the given vertices will form a loop.
+%%
+%%      Naive approach first: trying to link the same vertices
+%%
+%%      Second approach: let the digraph module figure it out,
+%%      creating an edge between the vertices and then catching
+%%      the {error, {bad_edge, _}} error.
+%%
+%%      As this second approach creates edges, we delete them all
+%%      after we're done (we don't want edges without an associated
+%%      pid).
+%%
+%%      We want to check this before spawning a lasp process, otherwise
+%%      an infinite loop can be created if the vertices form a loop.
+%%
+handle_call({is_loop, From, To}, _From, #state{dag=Dag}=State) ->
+    Response = case lists:member(To, From) of
+        true -> true;
+        false ->
+            Status = [digraph:add_edge(Dag, F, To) || F <- From],
+            {Ok, Filtered} = case lists:any(fun is_edge_error/1, Status) of
+                false -> {false, Status};
+                true ->
+                    {true, lists:filter(fun(X) ->
+                        not is_edge_error(X)
+                    end, Status)}
+            end,
+            digraph:del_edges(Dag, Filtered),
+            Ok
+    end,
+    {reply, Response, State};
+
+%% @doc For all V in Src, create an edge from V to Dst labelled with Pid.
+handle_call({add_edges, Src, Dst, Pid}, _From, #state{dag=Dag}=State) ->
+    %% @todo: Add metadata and duplicate checking.
+    Status = [digraph:add_edge(Dag, V, Dst, Pid) || V <- Src],
+    R = case lists:any(fun is_graph_error/1, Status) of
+        false -> ok;
+        true -> error
+    end,
+    {reply, R, State}.
+
+%% @private
+-spec handle_cast(term(), #state{}) -> {noreply, #state{}}.
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+%% @private
+-spec handle_info(term(), #state{}) -> {noreply, #state{}}.
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @private
+-spec terminate(term(), #state{}) -> term().
+terminate(_Reason, _State) ->
+    ok.
+
+%% @private
+-spec code_change(term() | {down, term()}, #state{}, term()) -> {ok, #state{}}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+is_graph_error({error, _}) ->
+    true;
+
+is_graph_error(_) ->
+    false.
+
+is_edge_error({error, {bad_edge, _}}) ->
+    true;
+
+is_edge_error(_) ->
+    false.

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -547,7 +547,7 @@ handle_call({bind, Id, Metadata0, Value}, _From,
 
 %% Bind two variables together.
 handle_call({bind_to, Id, DVId}, _From, #state{store=Store}=State) ->
-    {ok, _Pid} = ?CORE:bind_to(Id, DVId, Store, ?BIND, ?READ),
+    {ok, _Pid} = ?CORE:bind_to(Id, DVId, Store, ?WRITE, ?READ),
     {reply, ok, State};
 
 %% Perform an update, and ensure that we bump the logical clock as we

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -600,7 +600,7 @@ handle_call({intersection, Left, Right, Intersection},
             _From,
             #state{store=Store}=State) ->
     {ok, _Pid} = ?CORE:intersection(Left, Right, Intersection, Store,
-                                    ?BIND, ?READ, ?READ),
+                                    ?WRITE, ?READ, ?READ),
     {reply, ok, State};
 
 %% Spawn a process to compute the union.

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -89,6 +89,12 @@
                 ?CORE:bind(_AccId, _AccValue, _Store)
               end).
 
+-define(WRITE, fun(_Store) ->
+                 fun(_AccId, _AccValue) ->
+                   {ok, _} = ?CORE:bind(_AccId, _AccValue, _Store)
+                 end
+               end).
+
 -define(READ, fun(_Id, _Threshold) ->
                 ?CORE:read(_Id, _Threshold, Store)
               end).

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -584,7 +584,7 @@ handle_call({read, Id, Threshold}, From, #state{store=Store}=State) ->
 
 %% Spawn a process to perform a filter.
 handle_call({filter, Id, Function, AccId}, _From, #state{store=Store}=State) ->
-    {ok, _Pid} = ?CORE:filter(Id, Function, AccId, Store, ?BIND, ?READ),
+    {ok, _Pid} = ?CORE:filter(Id, Function, AccId, Store, ?WRITE, ?READ),
     {reply, ok, State};
 
 %% Spawn a process to compute a product.

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -611,12 +611,12 @@ handle_call({union, Left, Right, Union}, _From, #state{store=Store}=State) ->
 
 %% Spawn a process to perform a map with incremental computation.
 handle_call({map_inc, Id, Function, AccId}, _From, #state{store=Store}=State) ->
-    {ok, _Pid} = ?CORE:map(Id, Function, AccId, Store, ?BIND, ?READ_DELTA),
+    {ok, _Pid} = ?CORE:map(Id, Function, AccId, Store, ?WRITE, ?READ_DELTA),
     {reply, ok, State};
 
 %% Spawn a process to perform a map.
 handle_call({map, Id, Function, AccId}, _From, #state{store=Store}=State) ->
-    {ok, _Pid} = ?CORE:map(Id, Function, AccId, Store, ?BIND, ?READ),
+    {ok, _Pid} = ?CORE:map(Id, Function, AccId, Store, ?WRITE, ?READ),
     {reply, ok, State};
 
 %% Spawn a process to perform a fold.

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -605,7 +605,7 @@ handle_call({intersection, Left, Right, Intersection},
 
 %% Spawn a process to compute the union.
 handle_call({union, Left, Right, Union}, _From, #state{store=Store}=State) ->
-    {ok, _Pid} = ?CORE:union(Left, Right, Union, Store, ?BIND, ?READ,
+    {ok, _Pid} = ?CORE:union(Left, Right, Union, Store, ?WRITE, ?READ,
                              ?READ),
     {reply, ok, State};
 

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -591,7 +591,7 @@ handle_call({filter, Id, Function, AccId}, _From, #state{store=Store}=State) ->
 handle_call({product, Left, Right, Product},
             _From,
             #state{store=Store}=State) ->
-    {ok, _Pid} = ?CORE:product(Left, Right, Product, Store, ?BIND,
+    {ok, _Pid} = ?CORE:product(Left, Right, Product, Store, ?WRITE,
                                ?READ, ?READ),
     {reply, ok, State};
 

--- a/src/lasp_process.erl
+++ b/src/lasp_process.erl
@@ -74,7 +74,7 @@ init([ReadFuns, Function]) ->
     {ok, #state{read_funs=ReadFuns, function=Function}};
 
 init([ReadFuns, TransFun, WriteFun]) ->
-    %% @todo: Add new fields to state
+    %% @todo Add new fields to state
     {ok, #state{read_funs=ReadFuns, function={TransFun, WriteFun}}}.
 
 %% @doc Return list of read functions.
@@ -88,7 +88,7 @@ process(Args, #state{function=Function}=State) ->
         true ->
             ok;
         false ->
-            %% @todo: change this once state is changed
+            %% @todo change this once state is changed
             case Function of
                 {TransFun, {AccId, WriteFun}} ->
                     BindFun = gen_write_fun(AccId, WriteFun),

--- a/src/lasp_process.erl
+++ b/src/lasp_process.erl
@@ -59,7 +59,7 @@ start_dag_link([ReadFuns, TransFun, WriteFun]) ->
     lasp_dependence_dag:add_vertices(From),
     lasp_dependence_dag:add_vertex(To),
 
-    case lasp_dependence_dag:is_loop(From, To) of
+    case lasp_dependence_dag:will_form_cycle(From, To) of
         false ->
             {ok, Pid} = lasp_process_sup:start_child([ReadFuns, TransFun, WriteFun]),
             ok = lasp_dependence_dag:add_edges(From, To, Pid),

--- a/src/lasp_process.erl
+++ b/src/lasp_process.erl
@@ -28,7 +28,8 @@
 -endif.
 
 %% API
--export([start_link/1, start_dag_link/3]).
+-export([start_link/1,
+         start_dag_link/1]).
 
 %% Callbacks
 -export([init/1, read/1, process/2]).
@@ -50,7 +51,7 @@ start_link(Args) ->
     lasp_process_sup:start_child(Args).
 
 %% @todo move to lasp_process_sup ?
-start_dag_link(ReadFuns, TransFun, WriteFun) ->
+start_dag_link([ReadFuns, TransFun, WriteFun]) ->
     From = [Id || {Id, _} <- ReadFuns],
     {To, _} = WriteFun,
 

--- a/src/lasp_sup.erl
+++ b/src/lasp_sup.erl
@@ -44,6 +44,10 @@ start_link() ->
 %% ===================================================================
 
 init(_Args) ->
+    DepDag = {lasp_dependence_dag,
+              {lasp_dependence_dag, start_link, []},
+               permanent, 5000, worker, [lasp_dependence_dag]},
+
     Process = {lasp_process_sup,
                {lasp_process_sup, start_link, []},
                 permanent, infinity, supervisor, [lasp_process_sup]},
@@ -104,7 +108,8 @@ init(_Args) ->
                             permanent, 5000, worker,
                             [lasp_marathon_peer_refresh_service]},
 
-    BaseSpecs = [Unique,
+    BaseSpecs = [DepDag,
+                 Unique,
                  Partisan,
                  PlumtreeBackend,
                  Plumtree,


### PR DESCRIPTION
This pull request:

- Adds a prototype version of the dependency graph (5fb4b28afc52229aab73b0899c8b51fde0fe810d and b5454bf9654eca4a29933234e51aa15d6a2fe17d).

- Adds a "write" step to the lasp process (c8ccf43b5a63362e73e50b2d13472893aca8ecbe, 098a60389dc0e0ba18afcc80c703c771e2aead5e).
  This is what we discussed the other day.

    >Additional support for lasp processes in 3 steps: Read, Transform and
    >Write.

    >Now, instead of passing a single function that computes the changes and
    >then writes them to the appropiate CRDT, we pass two functions, one that
    >computes the new value, and another that writes the value.

- Tracks lasp processes as edges in the dag (1a4968944c12e0ff7cf26626cc5dc94c7ec4d0b4).
  It won't create the process if it detects that it will form a loop, but won't
  return an error.

  Additionally, it adds the input(s) and output vertices to the graph, but we
  should move this to declare and declare dynamic.

- Tracks `map`, `filter`, `stream`, `union`, `intersection`, `product` and `bind_to`.
  This is done by using the `lasp_process:start_dag_link/1` function, that
  expects a list of readfuns, a transforming function, and a write function.

  Todo: track `fold`.
