### PR TITLE
Merge all emanating edges into a single one

### DIFF
--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -346,9 +346,12 @@ collect_transform_functions(Edges) ->
 %%      into a new process that represents the union of all of them.
 %%
 -spec merge_unary(id(), id(), digraph:graph()) -> ok | pid().
-merge_unary(Src, Dst, G) ->
+merge_unary({_, orset}=Src, Dst, G) ->
     Edges = get_direct_edges_with_arity(G, Src, Dst, 1),
-    union_unary(Edges).
+    union_unary(Edges);
+
+merge_unary(_, _, _) ->
+    ok.
 
 %% @doc Given a list of edges, merge them together into a single one.
 %%

--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -359,6 +359,10 @@ merge_unary(Src, Dst, G) ->
 -spec union_unary([edge()]) -> ok | pid().
 union_unary([{_, Src, Dst, L}, _ | _]=Edges) ->
     %% If we have less than 2 edges, we are already optimized.
+    %%
+    %% Since this function merges all edges representing unary
+    %% functions, the optimization should only execute when we
+    %% have more than 2 edges.
 
     Read = {Src, L#edge_label.read},
 


### PR DESCRIPTION
For all vertices in the dag, merge all emanating edges representing
unary functions into a single one, that performs the union of all
functions in the old edges. Non-reversible.

![](https://dl.dropboxusercontent.com/u/29178650/case1small.png)

Incident edges on the child emanating from other nodes are preserved.

![](https://dl.dropboxusercontent.com/u/29178650/case2small.png)
