### PR TITLE
Track ephemerals (wip, don't merge)

### DIFF
--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -205,7 +205,7 @@ read(Id, Threshold, Store) ->
             {error, Reason};
 
         block -> receive
-            X -> X
+            {ok, {_Id, _Type, _Metadata, _Value}}=Res -> Res
         end
     end.
 

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -277,9 +277,18 @@ declare_dynamic(Id, Type, MetadataFun0, Store) ->
     declare(Id, Type, MetadataFun, Store).
 
 %% @doc Return the current value of a CRDT.
-%% @todo Why isn't this using the ReadFun?
+%%
+%%      Same as query_var, but tracked in the dag.
+%%
 -spec query(id(), store()) -> {ok, term()}.
-query({_, Type}=Id, Store) ->
+query(Id, Store) ->
+    lasp_process:single_fire_function(Id, query,
+                                      fun query_var/2, [Id, Store]).
+
+%% @doc Return the current value of a CRDT.
+%% @todo Why isn't this using the ReadFun?
+-spec query_var(id(), store()) -> {ok, term()}.
+query_var({_, Type}=Id, Store) ->
     Value = case do(get, [Store, Id]) of
         {ok, #dv{value=Value0, type=Type}} ->
             Value0;

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -472,7 +472,7 @@ bind_var(Origin, Id, Value, MetadataFun, Store) ->
 %%      Same as read_var, but tracked in the dag.
 %%
 -spec read(id(), value(), store(), pid(), function(), function()) ->
-    {ok, var()} | not_found().
+    {ok, var()} | not_found() | atom().
 read(Id, Threshold, Store, Self, ReplyFun, BlockingFun) ->
     lasp_process:single_fire_function(Id, read,
                                       fun read_var/6, [Id,
@@ -499,7 +499,7 @@ read(Id, Threshold, Store, Self, ReplyFun, BlockingFun) ->
 %%      variable is unbound or has not met the threshold yet.
 %%
 -spec read_var(id(), value(), store(), pid(), function(), function()) ->
-    {ok, var()} | not_found().
+    {ok, var()} | not_found() | atom().
 read_var(Id, Threshold0, Store, Self, ReplyFun, BlockingFun) ->
     Mutator = fun(#dv{type=Type, value=Value, metadata=Metadata, lazy_threads=LT}=Object) ->
             %% When no threshold is specified, use the bottom value for the

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -472,7 +472,7 @@ bind_var(Origin, Id, Value, MetadataFun, Store) ->
 %%      Same as read_var, but tracked in the dag.
 %%
 -spec read(id(), value(), store(), pid(), function(), function()) ->
-    {ok, var()} | not_found() | atom().
+    {ok, var()} | not_found() | block.
 read(Id, Threshold, Store, Self, ReplyFun, BlockingFun) ->
     lasp_process:single_fire_function(Id, read,
                                       fun read_var/6, [Id,
@@ -499,7 +499,7 @@ read(Id, Threshold, Store, Self, ReplyFun, BlockingFun) ->
 %%      variable is unbound or has not met the threshold yet.
 %%
 -spec read_var(id(), value(), store(), pid(), function(), function()) ->
-    {ok, var()} | not_found() | atom().
+    {ok, var()} | not_found() | block.
 read_var(Id, Threshold0, Store, Self, ReplyFun, BlockingFun) ->
     Mutator = fun(#dv{type=Type, value=Value, metadata=Metadata, lazy_threads=LT}=Object) ->
             %% When no threshold is specified, use the bottom value for the

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -182,6 +182,10 @@ read(Id, Store) ->
 %%      bound.
 %%
 %%      This operation blocks until `Threshold' has been reached.
+%%      As read/6 runs inside a lasp process, we have to block
+%%      outside, or else it may get killed when used in combination
+%%      with other lasp processes (for example, when used as the read
+%%      function of another lasp process).
 %%
 -spec read(id(), value(), store()) -> {ok, var()}.
 read(Id, Threshold, Store) ->

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -99,12 +99,12 @@
 
 -define(WRITE, fun(_Store) ->
                  fun(_AccId, _AccValue) ->
-                   {ok, _} = ?CORE:bind(_AccId, _AccValue, _Store)
+                   {ok, _} = ?CORE:bind_var(_AccId, _AccValue, _Store)
                  end
                end).
 
 -define(READ, fun(_Id, _Threshold) ->
-                ?CORE:read(_Id, _Threshold, Store)
+                ?CORE:read_var(_Id, _Threshold, Store)
               end).
 
 -define(BLOCKING, fun() -> {noreply, State} end).

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -104,7 +104,7 @@
                end).
 
 -define(READ, fun(_Id, _Threshold) ->
-                ?CORE:read(_Id, _Threshold, Store)
+                ?CORE:read_var(_Id, _Threshold, Store)
               end).
 
 -define(BLOCKING, fun() -> {noreply, State} end).

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -99,12 +99,12 @@
 
 -define(WRITE, fun(_Store) ->
                  fun(_AccId, _AccValue) ->
-                   {ok, _} = ?CORE:bind_var(_AccId, _AccValue, _Store)
+                   {ok, _} = ?CORE:bind(_AccId, _AccValue, _Store)
                  end
                end).
 
 -define(READ, fun(_Id, _Threshold) ->
-                ?CORE:read_var(_Id, _Threshold, Store)
+                ?CORE:read(_Id, _Threshold, Store)
               end).
 
 -define(BLOCKING, fun() -> {noreply, State} end).

--- a/src/lasp_plumtree_broadcast_distribution_backend.erl
+++ b/src/lasp_plumtree_broadcast_distribution_backend.erl
@@ -99,7 +99,7 @@
 
 -define(WRITE, fun(_Store) ->
                  fun(_AccId, _AccValue) ->
-                   {ok, _} = ?CORE:bind(_AccId, _AccValue, _Store)
+                   {ok, _} = ?CORE:bind_var(_AccId, _AccValue, _Store)
                  end
                end).
 

--- a/src/lasp_process.erl
+++ b/src/lasp_process.erl
@@ -72,6 +72,7 @@ start_tracked_process(EventCount, [ReadFuns, TransFun, {To, _}=WriteFun]) ->
         true -> case lasp_dependence_dag:will_form_cycle(From, To) of
             false -> lasp_process_sup:start_child(EventCount, [ReadFuns, TransFun, WriteFun]);
             true ->
+                lager:warning("dependence dag edge from ~w to ~w forms a cycle~n", [From, To]),
                 %% @todo propagate errors
                 {ok, ignore}
         end

--- a/src/lasp_process.erl
+++ b/src/lasp_process.erl
@@ -88,8 +88,6 @@ start_tracked_process(EventCount, [ReadFuns, TransFun, {To, _}=WriteFun]) ->
 %%
 single_fire_function(From, To, Fn, Args) ->
     Self = self(),
-    %% Unique reference, ignore any other messages.
-    %% @todo Remove?
     Ref = erlang:make_ref(),
 
     %% We don't care for the input.


### PR DESCRIPTION
Track `read` and `bind` in the dag. `query` is tracked too since it doesn't use `read`.

~~Old lasp processes use non-tracked versions (`read_var` and `bind_var`), since I
couldn't get them to work with the tracked versions.~~

~~Todo: track `read_any`~~
