### PR TITLE
Simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ install:
   - make
   - ./rebar3 update
 script:
-  - travis_wait sudo sh -c "ulimit -n 795197 && exec sudo -u travis bash -c 'source $HOME/otp/18.1/activate && MODE=state_based ulimit'"
-  - travis_wait sudo sh -c "ulimit -n 795197 && exec sudo -u travis bash -c 'source $HOME/otp/18.1/activate && MODE=state_based make ct'"
-  - travis_wait sudo sh -c "ulimit -n 795197 && exec sudo -u travis bash -c 'source $HOME/otp/18.1/activate && MODE=delta_based make ct'"
-  - make test
+  - make eunit
   - make xref
   - make dialyzer
   - make lint
@@ -19,3 +16,6 @@ notifications:
   slack: lasp-lang:hiPRNnbUa3zdGrrXZfGRAF7D
   irc: "irc.freenode.org#lasp-lang"
 sudo: required
+env:
+  global:
+    - OMIT_HIGH_ULIMIT=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,13 @@
+sudo: required
 language: erlang
-otp_release:
-  - 18.1
-install:
-  - make
-  - ./rebar3 update
+otp_release: 18.1
+install: true
+env: PATH=$PATH:. OMIT_HIGH_ULIMIT=true
 script:
-  - make eunit
-  - make xref
-  - make dialyzer
-  - make lint
-  - MODE=state_based make ct
-  - MODE=delta_based make ct
+- rebar3 update && make compile eunit xref dialyzer lint
+- MODE=state_based make ct
+- MODE=delta_based make ct
 notifications:
   email: christopher.meiklejohn@gmail.com
   slack: lasp-lang:hiPRNnbUa3zdGrrXZfGRAF7D
   irc: "irc.freenode.org#lasp-lang"
-sudo: required
-env:
-  global:
-    - OMIT_HIGH_ULIMIT=true

--- a/test/lasp_advertisement_counter_SUITE.erl
+++ b/test/lasp_advertisement_counter_SUITE.erl
@@ -127,13 +127,19 @@ state_based_ps_with_aae_test(Config) ->
     ok.
 
 state_based_ps_with_aae_and_tree_test(Config) ->
-    run(state_based_ps_with_aae_and_tree_test,
-        Config,
-        [{mode, state_based},
-         {set, awset_ps},
-         {broadcast, true},
-         {evaluation_identifier, state_based_ps_with_aae_and_tree}]),
-    ok.
+    case os:getenv("OMIT_HIGH_ULIMIT", "false") of
+        "false" ->
+            run(state_based_ps_with_aae_and_tree_test,
+                Config,
+                [{mode, state_based},
+                 {set, awset_ps},
+                 {broadcast, true},
+                 {evaluation_identifier, state_based_ps_with_aae_and_tree}]),
+            ok;
+        _ ->
+            %% Omit.
+            ok
+    end.
 
 delta_based_ps_with_aae_test(Config) ->
     run(delta_based_ps_with_aae_test,

--- a/test/lasp_advertisement_counter_SUITE.erl
+++ b/test/lasp_advertisement_counter_SUITE.erl
@@ -94,13 +94,19 @@ state_based_with_aae_test(Config) ->
     ok.
 
 state_based_with_aae_and_tree_test(Config) ->
-    run(state_based_with_aae_and_tree_test,
-        Config,
-        [{mode, state_based},
-         {set, orset},
-         {broadcast, true},
-         {evaluation_identifier, state_based_with_aae_and_tree}]),
-    ok.
+    case os:getenv("OMIT_HIGH_ULIMIT", "false") of
+        "false" ->
+            run(state_based_with_aae_and_tree_test,
+                Config,
+                [{mode, state_based},
+                 {set, orset},
+                 {broadcast, true},
+                 {evaluation_identifier, state_based_with_aae_and_tree}]),
+            ok;
+        _ ->
+            %% Omit.
+            ok
+    end.
 
 delta_based_with_aae_test(Config) ->
     run(delta_based_with_aae_test,

--- a/test/lasp_advertisement_counter_SUITE.erl
+++ b/test/lasp_advertisement_counter_SUITE.erl
@@ -166,13 +166,7 @@ run(Case, Config, Options) ->
             stop(Nodes)
         end,
         lists:seq(1, ?EVAL_NUMBER)
-    ),
-
-    %% Generate transmission plot.
-    ct:pal("Will generate plots for all executions of ~p", [Case]),
-    lasp_plot_gen:generate_plots(Options),
-
-    ok.
+    ).
 
 %% @private
 start(_Case, _Config, Options) ->


### PR DESCRIPTION
These changes are mostly :lipstick:, but I like the separation of the `install` and `script` steps.

It seemed like there was some unnecessarily redundant `make`-ing going on too.


~~You can check the status of the build [here](https://travis-ci.org/yurrriq/lasp/builds/143455676) in case Travis abides the `[ci skip]` for this PR.~~
**Edit**: Looks like it got killed due to lack of output for 10 minutes.

**N.B.** If you split the `env` entry across multiple lines, Travis will generate a separate build per line.
*[I learned this the hard way.]*