### PR TITLE
Dag path contraction

### DIFF
--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -752,11 +752,12 @@ contract(G, VSeq, State) ->
     {ok, NewState} = add_edges(nostep, [First], Last, Pid,
                                [Read], TransFun, Write, State),
 
-    OptMap = NewState#state.optimized_map,
+    NewDag   = NewState#state.dag,
+    OptMap   = NewState#state.optimized_map,
     PidTable = NewState#state.pid_table,
 
     %% Remove the intermediate edges by terminating the associated processes.
-    NewOptMap = remove_edges(G, VSeq, ProcessHash, Pid, OptMap),
+    NewOptMap = remove_edges(NewDag, VSeq, ProcessHash, Pid, OptMap),
 
     NewState#state{optimized_map = NewOptMap, pid_table = dict:store(Pid, ProcessHash, PidTable)}.
 

--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -95,12 +95,12 @@ add_edges(Src, Dst, Pid, ReadFuns, TransFun, WriteFun) ->
 %% @doc Return the dot representation as a string.
 -spec to_dot() -> {ok, string()} | {error, no_data}.
 to_dot() ->
-  gen_server:call(?MODULE, to_dot, infinity).
+    gen_server:call(?MODULE, to_dot, infinity).
 
 %% @doc Write the dot representation of the dag to the given file path.
 -spec export_dot(string()) -> ok | {error, no_data}.
 export_dot(Path) ->
-  gen_server:call(?MODULE, {export_dot, Path}, infinity).
+    gen_server:call(?MODULE, {export_dot, Path}, infinity).
 
 n_vertices() ->
     gen_server:call(?MODULE, n_vertices, infinity).

--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -68,7 +68,7 @@ start_link() ->
 
 -spec add_vertex(id()) -> ok.
 add_vertex(V) ->
-    gen_server:call(?MODULE, {add_vertex, V}, infinity).
+    add_vertices([V]).
 
 -spec add_vertices(list(id())) -> ok.
 add_vertices([]) ->
@@ -154,10 +154,6 @@ handle_call({out_edges, V}, _From, #state{dag=Dag}=State) ->
 handle_call({in_edges, V}, _From, #state{dag=Dag}=State) ->
     Edges = [digraph:edge(Dag, E) || E <- digraph:in_edges(Dag, V)],
     {reply, {ok, Edges}, State};
-
-handle_call({add_vertex, V}, _From, #state{dag=Dag}=State) ->
-    digraph:add_vertex(Dag, V),
-    {reply, ok, State};
 
 handle_call({add_vertices, Vs}, _From, #state{dag=Dag}=State) ->
     [digraph:add_vertex(Dag, V) || V <- Vs],

--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -607,7 +607,8 @@ remove_edges(Dag, VSeq, Pid, OptMap) ->
     end, dict:new(), get_metadata(Dag, VSeq)),
 
     %% Tag all unnecessary vertices in the path with the new process Pid
-    tag_unnecessary(Dag, VSeq, Pid),
+    UnnecesaryVertices = lists:sublist(VSeq, 2, length(VSeq) - 2),
+    tag_unnecessary(Dag, UnnecesaryVertices, Pid),
 
     %% Delete the intermediate edges and kill the associated processes.
     OldPids = collect_pids(Dag, VSeq),
@@ -649,10 +650,9 @@ get_metadata(G, V1, V2) ->
 %% @doc Tag the unnecessary vertices in the given path with a pid.
 -spec tag_unnecessary(digraph:graph(), contract_path(), pid()) -> ok.
 tag_unnecessary(Dag, VSeq, Pid) ->
-    Intermediate = lists:sublist(VSeq, 2, length(VSeq) - 2),
     lists:foreach(fun(V) ->
         digraph:add_vertex(Dag, V, #vertex_label{pointer_pid=Pid})
-    end, Intermediate).
+    end, VSeq).
 
 %% @doc Get the list of pids from the edges between V1 and V2
 -spec get_connecting_pids(digraph:graph(),

--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -485,7 +485,10 @@ maybe_unnecessary(G, V) ->
 %%%===================================================================
 
 to_dot(Graph) ->
-    case digraph_utils:topsort(Graph) of
+    Vertices = lists:filter(fun(V) ->
+        not (digraph:in_degree(Graph, V) =:= 0 andalso digraph:out_degree(Graph, V) =:= 0)
+    end, digraph_utils:topsort(Graph)),
+    case Vertices of
         [] -> {error, no_data};
         VertexList ->
             Start = ["digraph dag {\n"],

--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -81,9 +81,10 @@
 
 %% @todo Move somewhere else
 %% A tuple of the arguments of a lasp process.
--type process_args() :: {[{lasp_vertex(), function()}], function(), {lasp_vertex(), function()}}.
+-type process_args() :: {[{lasp_vertex(), function()}],
+                         function(),
+                         {lasp_vertex(), function()}}.
 
-%% @todo For now, maybe changed for another data structure
 -record(vertex_label, {pointer_pid :: pid()}).
 
 -type lasp_vertex() :: id() | pid().
@@ -340,6 +341,10 @@ handle_call({add_edges, Src, Dst, Pid, ReadFuns, TransFun, {Dst, WriteFun}},
             %%       won't be contracted, as they are determined to be changed
             %%       often. Only contract paths that are relatively stable
             %%       (haven't changed in X ticks).
+            %%
+            %%       Another option is to implement a special function to
+            %%       create edges in the graph that don't count towards
+            %%       the contraction step count.
             %%
             St0#state{contraction_step=0};
         _ ->

--- a/src/lasp_dependence_dag.erl
+++ b/src/lasp_dependence_dag.erl
@@ -24,10 +24,11 @@
          out_edges/1,
          in_edges/1]).
 
-%% @todo Only export on test. Optimization Debug
+-ifdef(TEST).
 -export([contract/0,
          cleave/1,
          cleave_all/0]).
+-endif.
 
 %% gen_server callbacks
 -export([init/1,
@@ -171,14 +172,37 @@ in_edges(V) ->
 process_map() ->
     gen_server:call(?MODULE, get_process_map, infinity).
 
+-ifdef(TEST).
+
+%% @doc Contract all suitable paths in the graph.
+%%
+%%      A path can be contracted if it contains one or more
+%%      unnecessary vertices. An unnecessary vertex is one
+%%      that only has one child and one parent.
+%%
+%%      This removes intermediate vertices from the graph.
+%%
 contract() ->
     gen_server:call(?MODULE, contract, infinity).
 
+%% @doc Perform vertex cleaving on the given vertex.
+%%
+%%      Given a vertex that was removed as part of a path contraction,
+%%      undo the contraction on all vertices of the path.
+%%
+%%      Does nothing if the vertex was not removed.
+%%
 cleave(Vertex) ->
     gen_server:call(?MODULE, {cleave, Vertex}, infinity).
 
+%% @doc Perform vertex cleaving on all removed vertices.
+%%
+%%      Same as cleave/1, but on all removed vertices of the graph.
+%%
 cleave_all() ->
     gen_server:call(?MODULE, cleave_all, infinity).
+
+-endif.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/src/lasp_process.erl
+++ b/src/lasp_process.erl
@@ -30,6 +30,7 @@
 %% API
 -export([start_link/1,
          start_dag_link/1,
+         start_manual_process/1,
          single_fire_function/4,
          start_single_fire_process/1]).
 
@@ -49,14 +50,28 @@
 %%% API
 %%%===================================================================
 
-start_link(Args) ->
-    lasp_process_sup:start_child(Args).
+start_link([ReadFuns, TransFun]) ->
+    start_manual_process([ReadFuns, TransFun, undefined]).
+
+%% @doc A lasp process that shouldn't be automatically managed by the dag
+%%
+%%      When using this function, the resulting process isn't tracked by
+%%      the runtime. Only useful when we want to manually introduce the
+%%      dependencies in the graph, or for functions that aren't currently
+%%      supported (fold and stream).
+%%
+start_manual_process([_ReadFuns, _TransFun, _WriteFun]=Args) ->
+    lasp_process_sup:start_child([nodag | Args]).
 
 %% @todo rename to start_link once all functions are tracked
 start_dag_link(Args) ->
     start_tracked_process(undefined, Args).
 
 %% @doc Starts a single-fire lasp process.
+%%
+%%      These processes only run until their transform functions complete
+%%      succesfully one time. Used to model reads and binds on values.
+%%
 start_single_fire_process(Args) ->
     start_tracked_process(1, Args).
 
@@ -115,10 +130,10 @@ single_fire_function(From, To, Fn, Args) ->
 %%%===================================================================
 
 %% @doc Initialize state.
-init([ReadFuns, Function]) ->
+init([nodag, ReadFuns, Function, WriteFun]) ->
     {ok, #state{read_funs=ReadFuns,
                 trans_fun=Function,
-                write_fun=undefined}};
+                write_fun=WriteFun}};
 
 init([ReadFuns, TransFun, {To, _}=WriteFun]) ->
     From = [Id || {Id, _} <- ReadFuns],

--- a/src/lasp_process.erl
+++ b/src/lasp_process.erl
@@ -72,7 +72,7 @@ start_tracked_process(EventCount, [ReadFuns, TransFun, {To, _}=WriteFun]) ->
         true -> case lasp_dependence_dag:will_form_cycle(From, To) of
             false -> lasp_process_sup:start_child(EventCount, [ReadFuns, TransFun, WriteFun]);
             true ->
-                lager:warning("dependence dag edge from ~w to ~w forms a cycle~n", [From, To]),
+                lager:warning("dependence dag edge from ~w to ~w would form a cycle~n", [From, To]),
                 %% @todo propagate errors
                 {ok, ignore}
         end

--- a/src/lasp_sup.erl
+++ b/src/lasp_sup.erl
@@ -104,7 +104,7 @@ init(_Args) ->
                   MarathonPeerRefresh,
                   Process] ++ WebSpecs,
 
-    DagEnabled = application:get_env(?APP, dag_enabled, false),
+    DagEnabled = application:get_env(?APP, dag_enabled, true),
     lasp_config:set(dag_enabled, DagEnabled),
     BaseSpecs = case DagEnabled of
         true -> [DepDag | BaseSpecs0];

--- a/src/lasp_sup.erl
+++ b/src/lasp_sup.erl
@@ -104,7 +104,7 @@ init(_Args) ->
                   MarathonPeerRefresh,
                   Process] ++ WebSpecs,
 
-    DagEnabled = application:get_env(?APP, dag_enabled, true),
+    DagEnabled = application:get_env(?APP, dag_enabled, false),
     lasp_config:set(dag_enabled, DagEnabled),
     BaseSpecs = case DagEnabled of
         true -> [DepDag | BaseSpecs0];

--- a/src/lasp_sup.erl
+++ b/src/lasp_sup.erl
@@ -244,7 +244,16 @@ configure_defaults() ->
                                ?APP,
                                incremental_computation_mode,
                                false),
-    lasp_config:set(incremental_computation_mode, IncrementalComputation).
+
+    %% Automatic contraction configuration.
+    %% Only makes sense if the dag is enabled.
+    lasp_config:set(incremental_computation_mode, IncrementalComputation),
+    case lasp_config:get(dag_enabled, false) of
+        true ->
+            AutomaticContraction = application:get_env(?APP, automatic_contraction, false),
+            lasp_config:set(automatic_contraction, AutomaticContraction);
+        _ -> ok
+    end.
 
 %% @private
 advertisement_counter_child_specs() ->

--- a/test/lasp_SUITE.erl
+++ b/test/lasp_SUITE.erl
@@ -226,7 +226,7 @@ latency_with_reads_test(_Config) ->
             end,
             case (Iterations rem 10) =:= 0 of
                 true ->
-                    RandomChoice = lists:nth(random:uniform(length(Intermediate)), Intermediate),
+                    RandomChoice = lists:nth(lasp_support:puniform(length(Intermediate)), Intermediate),
                     _ = lasp:read(RandomChoice, undefined);
                 _ -> ok
             end,

--- a/test/lasp_SUITE.erl
+++ b/test/lasp_SUITE.erl
@@ -181,7 +181,8 @@ combined_view_test(_Config) ->
 
 latency_test(_Config) ->
     RunCase = fun
-        RC(0, Acc, _, _, _, _) -> Acc;
+        RC(0, Acc, _, _, _, _) ->
+            lists:reverse(Acc);
         RC(Iterations, Acc, From, To, {add, N}=Mutator, Threshold0) ->
             Threshold = case Threshold0 of
                 undefined ->

--- a/test/lasp_SUITE.erl
+++ b/test/lasp_SUITE.erl
@@ -203,10 +203,10 @@ latency_test(_Config) ->
         {ok, {S4, _, _, _ }} = lasp:declare(?SET),
         {ok, {S5, _, _, _ }} = lasp:declare(?SET),
 
-        lasp:map(S1, fun(X) -> X + 1 end, S2),
-        lasp:map(S2, fun(X) -> X + 1 end, S3),
-        lasp:map(S3, fun(X) -> X + 1 end, S4),
-        lasp:filter(S4, fun(X) -> (X rem 2) =:= 0 end, S5),
+        lasp:map(S1, fun(X) -> X end, S2),
+        lasp:map(S2, fun(X) -> X end, S3),
+        lasp:map(S3, fun(X) -> X end, S4),
+        lasp:filter(S4, fun(_X) -> true end, S5),
         case Optimization of
             contraction -> lasp_dependence_dag:contract();
             _ -> ok

--- a/test/lasp_SUITE.erl
+++ b/test/lasp_SUITE.erl
@@ -183,7 +183,7 @@ latency_test(_Config) ->
     RunCase = fun
         RC(0, Acc, _, _, _, _) ->
             lists:reverse(Acc);
-        RC(Iterations, Acc, From, To, {add, N}=Mutator, Threshold0) ->
+        RC(Iterations, Acc, From, To, Mutator, Threshold0) ->
             Threshold = case Threshold0 of
                 undefined ->
                     {strict, undefined};
@@ -195,24 +195,24 @@ latency_test(_Config) ->
                 lasp:read(T, Th)
             end,
             {Time, {ok, {_, _, _, NewThreshold}}} = timer:tc(MutateAndRead, [From, To, Mutator, Threshold]),
-            RC(Iterations - 1, [Time | Acc], From, To, {add, N+1}, NewThreshold)
+            RC(Iterations - 1, [Time | Acc], From, To, Mutator, NewThreshold)
     end,
     TestCase = fun(Optimization, Iterations) ->
-        {ok, {S1, _, _, _ }} = lasp:declare(?SET),
-        {ok, {S2, _, _, _ }} = lasp:declare(?SET),
-        {ok, {S3, _, _, _ }} = lasp:declare(?SET),
-        {ok, {S4, _, _, _ }} = lasp:declare(?SET),
-        {ok, {S5, _, _, _ }} = lasp:declare(?SET),
+        {ok, {S1, _, _, _ }} = lasp:declare(?COUNTER),
+        {ok, {S2, _, _, _ }} = lasp:declare(?COUNTER),
+        {ok, {S3, _, _, _ }} = lasp:declare(?COUNTER),
+        {ok, {S4, _, _, _ }} = lasp:declare(?COUNTER),
+        {ok, {S5, _, _, _ }} = lasp:declare(?COUNTER),
 
-        lasp:map(S1, fun(X) -> X end, S2),
-        lasp:map(S2, fun(X) -> X end, S3),
-        lasp:map(S3, fun(X) -> X end, S4),
-        lasp:filter(S4, fun(_X) -> true end, S5),
+        lasp:bind_to(S2, S1),
+        lasp:bind_to(S3, S2),
+        lasp:bind_to(S4, S3),
+        lasp:bind_to(S5, S4),
         case Optimization of
             contraction -> lasp_dependence_dag:contract();
             _ -> ok
         end,
-        RunCase(Iterations, [], S1, S5, {add, 1}, undefined)
+        RunCase(Iterations, [], S1, S5, increment, undefined)
     end,
     write_csv(contraction, TestCase(contraction, 1000)),
     write_csv(no_contraction, TestCase(no_contraction, 1000)).

--- a/test/lasp_SUITE.erl
+++ b/test/lasp_SUITE.erl
@@ -184,8 +184,10 @@ latency_test(_Config) ->
         RC(0, Acc, _, _, _, _) -> Acc;
         RC(Iterations, Acc, From, To, {add, N}=Mutator, Threshold0) ->
             Threshold = case Threshold0 of
-                undefined -> {strict, undefined};
-                _ -> Threshold0
+                undefined ->
+                    {strict, undefined};
+                _ ->
+                    {strict, Threshold0}
             end,
             MutateAndRead = fun(F, T, M, Th) ->
                 lasp:update(F, M, a),

--- a/test/lasp_SUITE.erl
+++ b/test/lasp_SUITE.erl
@@ -79,6 +79,7 @@ all() ->
      parser_test,
      combined_view_test,
      latency_test,
+     latency_with_reads_test,
      stream_test,
      query_test,
      ivar_test,
@@ -207,6 +208,47 @@ latency_test(_Config) ->
     end,
     write_csv(contraction, TestCase(5, contraction, 1000)),
     write_csv(no_contraction, TestCase(5, no_contraction, 1000)).
+
+latency_with_reads_test(_Config) ->
+    RunCase = fun
+        RC(0, Acc, _, _, _, _, _) ->
+            lists:reverse(Acc);
+        RC(Iterations, Acc, From, To, Intermediate, Mutator, Threshold0) ->
+            Threshold = case Threshold0 of
+                undefined ->
+                    {strict, undefined};
+                _ ->
+                    {strict, Threshold0}
+            end,
+            case ((Iterations + 1) rem 10) =:= 0 of
+                true -> lasp_dependence_dag:contract();
+                _ -> ok
+            end,
+            case (Iterations rem 10) =:= 0 of
+                true ->
+                    RandomChoice = lists:nth(random:uniform(length(Intermediate)), Intermediate),
+                    _ = lasp:read(RandomChoice, undefined);
+                _ -> ok
+            end,
+            MutateAndRead = fun(F, T, M, Th) ->
+                lasp:update(F, M, a),
+                lasp:read(T, Th)
+            end,
+            {Time, {ok, {_, _, _, NewThreshold}}} = timer:tc(MutateAndRead, [From, To, Mutator, Threshold]),
+            RC(Iterations - 1, [Time | Acc], From, To, Intermediate, Mutator, NewThreshold)
+    end,
+    TestCase = fun(Vertices, Optimization, Iterations) ->
+        Ids = generate_path(Vertices, ?COUNTER),
+        case Optimization of
+            contraction -> lasp_dependence_dag:contract();
+            _ -> ok
+        end,
+        First = lists:nth(1, Ids),
+        Last = lists:last(Ids),
+        Intermediate = lists:sublist(Ids, 2, erlang:length(Ids) - 2),
+        RunCase(Iterations, [], First, Last, Intermediate, increment, undefined)
+    end,
+    write_csv(contraction_with_reads, TestCase(5, contraction, 1000)).
 
 generate_path(N, Type) ->
     [_|Tail]=Ids = lists:map(fun(_) ->

--- a/test/lasp_SUITE.erl
+++ b/test/lasp_SUITE.erl
@@ -187,25 +187,32 @@ latency_test(_Config) ->
                 undefined -> {strict, undefined};
                 _ -> Threshold0
             end,
-            lasp:update(From, Mutator, a),
-            {Time, {ok, {_, _, _, NewThreshold}}} = timer:tc(lasp, read, [To, Threshold]),
+            MutateAndRead = fun(F, T, M, Th) ->
+                lasp:update(F, M, a),
+                lasp:read(T, Th)
+            end,
+            {Time, {ok, {_, _, _, NewThreshold}}} = timer:tc(MutateAndRead, [From, To, Mutator, Threshold]),
             RC(Iterations - 1, [Time | Acc], From, To, {add, N+1}, NewThreshold)
     end,
     TestCase = fun(Optimization, Iterations) ->
         {ok, {S1, _, _, _ }} = lasp:declare(?SET),
         {ok, {S2, _, _, _ }} = lasp:declare(?SET),
         {ok, {S3, _, _, _ }} = lasp:declare(?SET),
+        {ok, {S4, _, _, _ }} = lasp:declare(?SET),
+        {ok, {S5, _, _, _ }} = lasp:declare(?SET),
 
         lasp:map(S1, fun(X) -> X + 1 end, S2),
-        lasp:filter(S2, fun(X) -> (X rem 2) =:= 0 end, S3),
+        lasp:map(S2, fun(X) -> X + 1 end, S3),
+        lasp:map(S3, fun(X) -> X + 1 end, S4),
+        lasp:filter(S4, fun(X) -> (X rem 2) =:= 0 end, S5),
         case Optimization of
             contraction -> lasp_dependence_dag:contract();
             _ -> ok
         end,
-        RunCase(Iterations, [], S1, S3, {add, 1}, undefined)
+        RunCase(Iterations, [], S1, S5, {add, 1}, undefined)
     end,
-    write_csv(contraction, TestCase(contraction, 100)),
-    write_csv(no_contraction, TestCase(no_contraction, 100)).
+    write_csv(contraction, TestCase(contraction, 1000)),
+    write_csv(no_contraction, TestCase(no_contraction, 1000)).
 
 write_csv(Option, Cases) ->
     Path = code:priv_dir(lasp)


### PR DESCRIPTION
This PR implements path contraction and cleaving as a way to remove intermediate vertices in the graph.

#### What's working:

- Detection of suitable paths to be contracted.

- Explicit optimization passes (calling `lasp_dependence_dag:contract()` will contract all suitable paths in the graph).

- Automatic cleaving based on vertex access behaviours. (Creating new edges involving removed vertices undoes any optimizations involving that vertex).

- Cycle detection on removed edges (`lasp_dependence_dag:will_form_cycle` will detect cycles even if the vertices were removed during a contraction in the graph).

- Autoupdating of vertex tags on process restart.

- Automatic contraction passes.

#### To be implemented:

- [X] ~~Removed vertices hold a reference to the Pid of the process that connects endpoints in the contracted path. This reference is not updated if that process is restarted. This means that if that process is restarted, any future attempts to cleave the vertices in that path will fail.~~

- [X] ~~Automatic optimization passes. Think about how often optimization passes should occur.~~

#### Issues

- Since cleavings happen _after_ an edge is created, reads and queries may be able to get old data from a removed vertex. This is not a problem with binds or updates since downstream values will eventually get the new value once the cleaving finishes.