### PR TITLE
Buffer updates to plumtree.

### DIFF
--- a/src/lasp_default_broadcast_distribution_backend.erl
+++ b/src/lasp_default_broadcast_distribution_backend.erl
@@ -533,7 +533,7 @@ handle_call(perform_broadcast,
                     ok
               end, ok, ToBroadcast0),
 
-    %% Buffer latest update for that state.
+    %% Reset state.
     ToBroadcast = dict:new(),
 
     %% Reschedule broadcast.


### PR DESCRIPTION
Plumtree can be easily overloaded; so periodically buffer updates and
broadcast them in an effort to reduce this problem.