### PR TITLE
Add object filter for convergence structure.

### DIFF
--- a/src/lasp_default_broadcast_distribution_backend.erl
+++ b/src/lasp_default_broadcast_distribution_backend.erl
@@ -783,14 +783,14 @@ handle_cast({delta_exchange, Peer, ObjectFilterFun},
                                    Keys ->
                                        lists:min(Keys)
                                end,
-                                Deltas = case orddict:is_empty(DeltaMap) orelse Min > Ack of
+                               Deltas = case orddict:is_empty(DeltaMap) orelse Min > Ack of
                                    true ->
                                        Value;
                                    false ->
                                        collect_deltas(Peer, Type, DeltaMap, Ack, Counter)
-                                end,
-                                send({delta_send, node(), {Id, Type, Metadata, Deltas}, Counter}, Peer),
-                                [{ok, Id}|Acc0];
+                               end,
+                               send({delta_send, node(), {Id, Type, Metadata, Deltas}, Counter}, Peer),
+                               [{ok, Id}|Acc0];
                            false ->
                                Acc0
                        end

--- a/src/lasp_simulation_support.erl
+++ b/src/lasp_simulation_support.erl
@@ -172,6 +172,10 @@ start(_Case, _Config, Options) ->
                         HeavyClient = proplists:get_value(heavy_client, Options, false),
                         ok = rpc:call(Node, lasp_config, set, [heavy_client, HeavyClient]),
 
+                        %% Configure reactive server.
+                        ReactiveServer = proplists:get_value(reactive_server, Options, false),
+                        ok = rpc:call(Node, lasp_config, set, [reactive_server, ReactiveServer]),
+
                         %% Configure partitions.
                         PartitionProbability = proplists:get_value(partition_probability, Options, 0),
                         ok = rpc:call(Node, lasp_config, set, [partition_probability, PartitionProbability]),

--- a/src/lasp_sup.erl
+++ b/src/lasp_sup.erl
@@ -247,6 +247,12 @@ configure_defaults() ->
                                        HeavyClientsDefault),
     lasp_config:set(heavy_clients, HeavyClients),
 
+    ReactiveServerDefault = list_to_atom(os:getenv("REACTIVE_SERVER", "false")),
+    ReactiveServer = application:get_env(?APP,
+                                       reactive_server,
+                                       ReactiveServerDefault),
+    lasp_config:set(reactive_server, ReactiveServer),
+
     PartitionProbabilityDefault = list_to_integer(os:getenv("PARTITION_PROBABILITY", "0")),
     PartitionProbability = application:get_env(?APP,
                                                partition_probability,

--- a/test/lasp_client_server_advertisement_counter_SUITE.erl
+++ b/test/lasp_client_server_advertisement_counter_SUITE.erl
@@ -62,7 +62,9 @@ end_per_testcase(Case, _Config) ->
 all() ->
     [
      client_server_state_based_with_aae_test,
-     client_server_delta_based_with_aae_test%%,
+     client_server_delta_based_with_aae_test,
+     reactive_client_server_state_based_with_aae_test,
+     reactive_client_server_delta_based_with_aae_test
      %%client_server_state_based_ps_with_aae_test,
      %%client_server_delta_based_ps_with_aae_test
     ].
@@ -97,8 +99,33 @@ client_server_delta_based_with_aae_test(Config) ->
          {partisan_peer_service_manager, partisan_client_server_peer_service_manager},
          {set, orset},
          {broadcast, false},
+         {reactive_server, true},
          {evaluation_identifier, client_server_delta_based_with_aae}]),
     ok.
+
+reactive_client_server_state_based_with_aae_test(Config) ->
+    lasp_simulation_support:run(reactive_client_server_ad_counter_state_based_with_aae_test,
+        Config,
+        [{mode, state_based},
+         {simulation, ad_counter},
+         {partisan_peer_service_manager, partisan_client_server_peer_service_manager},
+         {set, orset},
+         {broadcast, false},
+         {reactive_server, true},
+         {evaluation_identifier, client_server_state_based_with_aae}]),
+    ok.
+
+client_server_delta_based_with_aae_test(Config) ->
+    lasp_simulation_support:run(client_server_ad_counter_delta_based_with_aae_test,
+        Config,
+        [{mode, delta_based},
+         {simulation, ad_counter},
+         {partisan_peer_service_manager, partisan_client_server_peer_service_manager},
+         {set, orset},
+         {broadcast, false},
+         {evaluation_identifier, client_server_delta_based_with_aae}]),
+    ok.
+
 
 client_server_state_based_ps_with_aae_test(Config) ->
     lasp_simulation_support:run(client_server_ad_counter_state_based_ps_with_aae_test,

--- a/test/lasp_client_server_advertisement_counter_SUITE.erl
+++ b/test/lasp_client_server_advertisement_counter_SUITE.erl
@@ -99,7 +99,6 @@ client_server_delta_based_with_aae_test(Config) ->
          {partisan_peer_service_manager, partisan_client_server_peer_service_manager},
          {set, orset},
          {broadcast, false},
-         {reactive_server, true},
          {evaluation_identifier, client_server_delta_based_with_aae}]),
     ok.
 
@@ -112,20 +111,20 @@ reactive_client_server_state_based_with_aae_test(Config) ->
          {set, orset},
          {broadcast, false},
          {reactive_server, true},
-         {evaluation_identifier, client_server_state_based_with_aae}]),
+         {evaluation_identifier, reactive_client_server_state_based_with_aae}]),
     ok.
 
-client_server_delta_based_with_aae_test(Config) ->
-    lasp_simulation_support:run(client_server_ad_counter_delta_based_with_aae_test,
+reactive_client_server_delta_based_with_aae_test(Config) ->
+    lasp_simulation_support:run(reactive_client_server_ad_counter_delta_based_with_aae_test,
         Config,
         [{mode, delta_based},
          {simulation, ad_counter},
          {partisan_peer_service_manager, partisan_client_server_peer_service_manager},
          {set, orset},
          {broadcast, false},
-         {evaluation_identifier, client_server_delta_based_with_aae}]),
+         {reactive_server, true},
+         {evaluation_identifier, reactive_client_server_delta_based_with_aae}]),
     ok.
-
 
 client_server_state_based_ps_with_aae_test(Config) ->
     lasp_simulation_support:run(client_server_ad_counter_state_based_ps_with_aae_test,


### PR DESCRIPTION
Allow the convergence function to synchronize when there are partitions,
by using a user supplied filter function for filtering out the objects
to synchronize.