### PR TITLE
resolve incorrect include path.

### DIFF
--- a/src/lasp_config.erl
+++ b/src/lasp_config.erl
@@ -26,6 +26,7 @@
 -export([dispatch/0,
          set/2,
          get/2,
+         peer_service_manager/0,
          web_config/0]).
 
 get(Key, Default) ->
@@ -60,3 +61,8 @@ web_config() ->
     Node = node(),
     lager:info("Node ~p enabling web configuration: ~p", [Node, Config]),
     Config.
+
+%% @private
+peer_service_manager() ->
+    partisan_config:get(partisan_peer_service_manager,
+                        partisan_default_peer_service_manager).

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -1025,7 +1025,7 @@ increment_counter(Counter) ->
 %%      map, which means, it will always send the full state to the
 %%      clients.
 store_delta(Origin, Counter, Delta, DeltaMap0) ->
-    case lasp_config:get(peer_service_manager, partisan_peer_service) == partisan_client_server_peer_service_manager andalso
+    case lasp_config:peer_service_manager() == partisan_client_server_peer_service_manager andalso
          partisan_config:get(tag, undefined) == server of
         true ->
             DeltaMap0;

--- a/src/lasp_default_broadcast_distribution_backend.erl
+++ b/src/lasp_default_broadcast_distribution_backend.erl
@@ -915,8 +915,7 @@ handle_info(delta_sync, #state{}=State) ->
     %% Get the active set from the membership protocol.
     {ok, Members} = membership(),
 
-    PeerServiceManager = lasp_config:get(peer_service_manager,
-                                         partisan_peer_service),
+    PeerServiceManager = lasp_config:peer_service_manager(),
     lager:info("Manager is: ~p, Members are: ~p",
                [PeerServiceManager, Members]),
 
@@ -1273,8 +1272,7 @@ memory_utilization_report() ->
 %% @private
 send(Msg, Peer) ->
     log_transmission(extract_log_type_and_payload(Msg), 1),
-    PeerServiceManager = lasp_config:get(peer_service_manager,
-                                         partisan_peer_service),
+    PeerServiceManager = lasp_config:peer_service_manager(),
     case PeerServiceManager:forward_message(Peer, ?MODULE, Msg) of
         ok ->
             ok;
@@ -1337,8 +1335,7 @@ shuffle(L) ->
 
 %% @private
 compute_exchange(Peers) ->
-    PeerServiceManager = lasp_config:get(peer_service_manager,
-                                         partisan_peer_service),
+    PeerServiceManager = lasp_config:peer_service_manager(),
 
     Probability = lasp_config:get(partition_probability, 0),
     lager:info("Probability of partition: ~p", [Probability]),
@@ -1405,11 +1402,11 @@ tutorial_mode() ->
 
 %% @private
 client_server_mode() ->
-    lasp_config:get(peer_service_manager, partisan_peer_service) == partisan_client_server_peer_service_manager.
+    lasp_config:peer_service_manager() == partisan_client_server_peer_service_manager.
 
 %% @private
 peer_to_peer_mode() ->
-    lasp_config:get(peer_service_manager, partisan_peer_service) == partisan_hyparview_peer_service_manager.
+    lasp_config:peer_service_manager() == partisan_hyparview_peer_service_manager.
 
 %% @private
 i_am_server() ->

--- a/src/lasp_sup.erl
+++ b/src/lasp_sup.erl
@@ -266,13 +266,6 @@ configure_defaults() ->
                                                PartitionProbabilityDefault),
     lasp_config:set(partition_probability, PartitionProbability),
 
-    %% Peer service.
-    PeerService = application:get_env(plumtree,
-                                      peer_service,
-                                      partisan_peer_service),
-    PeerServiceManager = PeerService:manager(),
-    lasp_config:set(peer_service_manager, PeerServiceManager),
-
     %% Exchange mode.
     case Mode of
         delta_based ->

--- a/src/sprinter.erl
+++ b/src/sprinter.erl
@@ -154,8 +154,7 @@ handle_cast(Msg, State) ->
 -spec handle_info(term(), #state{}) -> {noreply, #state{}}.
 handle_info(?REFRESH_MESSAGE, #state{attempted_nodes=SeenNodes}=State) ->
     Tag = partisan_config:get(tag, client),
-    PeerServiceManager = lasp_config:get(peer_service_manager,
-                                         partisan_peer_service),
+    PeerServiceManager = lasp_config:peer_service_manager(),
 
     %% Get list of nodes to connect to: this specialized logic isn't
     %% required when the node count is small, but is required with a


### PR DESCRIPTION
This parameter does not reflect the proper configuration of the
peer_service_manager in partisan, so remove it in favor of the other
configuration parameter.