### PR TITLE
Support state-based partition injection.

### DIFF
--- a/src/lasp_default_broadcast_distribution_backend.erl
+++ b/src/lasp_default_broadcast_distribution_backend.erl
@@ -895,8 +895,8 @@ handle_info(aae_sync, #state{store=Store} = State) ->
     %% Get the active set from the membership protocol.
     {ok, Members} = membership(),
 
-    %% Remove ourself.
-    Peers = Members -- [node()],
+    %% Remove ourself and compute exchange peers.
+    Peers = compute_exchange(without_me(Members)),
 
     lasp_logger:extended("Beginning sync for peers: ~p", [Peers]),
 


### PR DESCRIPTION
Support the ability to use the partitioning percentage in the normal
state-based AAE exchanges.