### PR TITLE
Return list from tutorial query

### DIFF
--- a/src/tutorial.erl
+++ b/src/tutorial.erl
@@ -59,7 +59,7 @@ query(Id, Type) ->
     %% Ensure the object is declared.
     {ok, Value} = lasp:query(Identifier),
 
-    Value.
+    sets:to_list(Value).
 
 mutate(Id, Type, Operation) ->
     %% Convert actor to binary representation.


### PR DESCRIPTION
While the data structure is a set, the tutorial code is designed to
simplify the use and understanding of the interfaces, not to be
correct from an API standpoint. Those who would use the library would
not presumably rely on a tutorial wrapper.