### PR TITLE
Return tuple from tutorial:query/2 instead of sets

### DIFF
--- a/src/tutorial.erl
+++ b/src/tutorial.erl
@@ -59,7 +59,13 @@ query(Id, Type) ->
     %% Ensure the object is declared.
     {ok, Value} = lasp:query(Identifier),
 
-    Value.
+    tutorial_query_result(Value).
+
+tutorial_query_result(Value) ->
+    case sets:is_set(Value) of
+        true -> list_to_tuple(sets:to_list(Value));
+        false -> Value
+    end.
 
 mutate(Id, Type, Operation) ->
     %% Convert actor to binary representation.


### PR DESCRIPTION
While the data structure is a set, the tutorial code is designed to
simplify the use and understanding of the interfaces, not to be
correct from an API standpoint. Those who would use the library would
not presumably rely on a tutorial wrapper.

A tuple in this case can be used to differentiate sets from sequences