### PR TITLE
move erlcloud to just be in the release and rm unused plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -28,8 +28,6 @@
 {yrl_first_files, ["src/lasp_sql_parser.yrl"]}.
 
 {cover_enabled, true}.
-{plugins, [{pc, {git, "https://github.com/blt/port_compiler.git", {branch, "master"}}},
-           rebar3_auto]}.
 
 {erl_opts, [debug_info,
             warnings_as_errors,
@@ -42,6 +40,9 @@
 {xref_queries, [{"(XC - UC) || (XU - X - B - \"(dtrace)\" : Mod)", []}]}.
 
 {profiles, [
+    {auto,  [
+        {plugins, [rebar3_auto]}
+    ]},
     {package,  [
         {plugins, [rebar3_hex]}
     ]},
@@ -111,7 +112,7 @@
     ]
 }.
 
-{relx, [{release, {lasp, "0.0.5"}, [lasp]},
+{relx, [{release, {lasp, "0.0.5"}, [lasp, erlcloud]},
         {extended_start_script, true},
 
         {dev_mode, true},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,8 @@
-[{<<"eini">>,{pkg,<<"eini">>,<<"1.2.1">>},1},
+{"1.1.0",
+[{<<"eini">>,{pkg,<<"eini">>,<<"1.2.4">>},1},
  {<<"erlcloud">>,
   {git,"https://github.com/erlcloud/erlcloud.git",
-       {ref,"be805cf4916c709c50797a687b94cf0b539f8025"}},
+       {ref,"9f366edb9f1339cd71a5ef61d6de45c456ca9002"}},
   0},
  {<<"gb_trees_ext">>,
   {git,"https://github.com/lasp-lang/gb_trees_ext.git",
@@ -67,4 +68,9 @@
  {<<"webmachine">>,
   {git,"https://github.com/webmachine/webmachine.git",
        {ref,"b4758b51c05e8f4e8898a70b7a14514a8c150ffa"}},
-  0}].
+  0}]}.
+[
+{pkg_hash,[
+ {<<"eini">>, <<"ABD64A0533398A6D714D21219BB85F2D41FDB42665AC4080939B7BFA8E55F386">>},
+ {<<"lhttpc">>, <<"61760AFEC1DDB98E47972BE93B13FBFF487A63D65B91A02C41122A0ADF83DA38">>}]}
+].

--- a/src/lasp.app.src
+++ b/src/lasp.app.src
@@ -9,7 +9,7 @@
      {registered,[]},
      {applications,
          [kernel,stdlib,types,gen_flow,lager,gb_trees_ext,sasl,time_compat,
-          webmachine,jsx,os_mon,lasp_support,rand_compat,erlcloud]},
+          webmachine,jsx,os_mon,lasp_support,rand_compat]},
      {mod,{lasp_app,[]}},
      {env,
          [{data_root,"data"},


### PR DESCRIPTION
The `pc` plugin does not appear to be used, so I've removed it from the config. I moved the `rebar3_auto` plugin to a new profile `auto` to be used as `rebar3 as auto auto` (I know that is kind of annoying, better to put personal dev tools like that in your global rebar3 config).

I also moved `erlcloud` to the relx config instead of .app.src. This allows me to override the lasp deps from my project to remove erlcloud without it complaining.

Do you do your experiments by running the release? If so this should be fine, if not then I'll have write something to remove it from the .app.src file of lasp on my end instead.