### PR TITLE
Fix failure to converge in reactive mode.

### DIFF
--- a/src/lasp_default_broadcast_distribution_backend.erl
+++ b/src/lasp_default_broadcast_distribution_backend.erl
@@ -783,28 +783,19 @@ handle_cast({delta_exchange, Peer, ObjectFilterFun},
                         collect_deltas(Peer, Type, DeltaMap, Ack, Counter)
                 end,
 
-                AckMap = case lasp_type:is_bottom(Type, Deltas) of
-                    true ->
-                        %% If the delta group is bottom, don't send it
-                        %% Also, don't update the GCCounter for this peer.
-                        AckMap0;
-                    false ->
-                        send({delta_send, node(), {Id, Type, Metadata, Deltas}, Counter}, Peer),
+                send({delta_send, node(), {Id, Type, Metadata, Deltas}, Counter}, Peer),
 
-                        %% In every exchange, increment GCCounter for that node.
-                        %% This value is reseted to 0 when a new ack is received.
-                        orddict:map(
-                            fun(Peer0, {Ack0, GCCounter0}) ->
-                                case Peer0 of
-                                    Peer ->
-                                        {Ack0, GCCounter0 + 1};
-                                    _ ->
-                                        {Ack0, GCCounter0}
-                                end
-                            end,
-                            AckMap0
-                        )
-                end,
+                AckMap = orddict:map(
+                    fun(Peer0, {Ack0, GCCounter0}) ->
+                        case Peer0 of
+                            Peer ->
+                                {Ack0, GCCounter0 + 1};
+                            _ ->
+                                {Ack0, GCCounter0}
+                        end
+                    end,
+                    AckMap0
+                ),
 
                 {Object#dv{delta_ack_map=AckMap}, Id};
             false ->
@@ -814,6 +805,8 @@ handle_cast({delta_exchange, Peer, ObjectFilterFun},
 
     %% TODO: Should this be parallel?
     {ok, _} = do(update_all, [Store, Mutator]),
+
+    lasp_logger:extended("Exchange finished for ~p", [Peer]),
 
     {noreply, State};
 


### PR DESCRIPTION
When a node creates a CRDT by declaring it, but without issuing an
actual mutation, it will create a bottom delta that *has* to be shipped
to the clients for them to bootstrap the object.

This is particularly problematic when the following happens:

1.) Server creates the CRDTs (at bottom.)
2.) Server sends them to client.
3.) Client performs the first mutation.

In this example, if the empty delta never gets sent to the clients, the
clients will never update the CRDT, therefore, they won't synchronize
the objects with the server, which will prevent the test from ever
converging.