### PR TITLE
do not warn/error on deprecated gen_fsm:send_event/2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,6 +26,7 @@
 
 {erl_opts, [debug_info,
             warnings_as_errors,
+            nowarn_deprecated_function,
             {platform_define, "^[0-9]+", namespaced_types},
             {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.


### PR DESCRIPTION
I had tried `{nowarn_deprecated_function, [{gen_fsm, send_event, 2}]},` but this did not work for some reason, I'm going to ask around about that and possibly have to file a bug with OTP if I really am doing it right.