### PR TITLE
Ensure membership is always a list.

### DIFF
--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -99,7 +99,17 @@ enforce_once(Id, Threshold, EnforceFun, Store) ->
                    case lasp_type:threshold_met(Type, Value, Threshold) of
                        true ->
                            {ok, Membership} = lasp:query(?MEMBERSHIP_ID),
-                           SortedMembership = lists:usort(Membership),
+
+                           Membership1 = case Membership of
+                               undefined ->
+                                   %% This is a register, and not a set so if this hasn't
+                                   %% been set yet, it's going to be bottom - undefined.
+                                   [];
+                                L ->
+                                    L
+                           end,
+
+                           SortedMembership = lists:usort(Membership1),
                            EnforcementNode = hd(SortedMembership),
 
                            case node() of


### PR DESCRIPTION
Given that a register has a bottom value of undefined and not empty list, you need to convert this to ensure when it's undefined that it is actually a list.