### PR TITLE
Bump the version of Erlang mentioned in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Lasp is a programming model for synchronization-free computations.
 
 ## Installing
 
-Lasp requires Erlang 18 or greater.  Once you have Erlang installed, do
+Lasp requires Erlang 19 or greater.  Once you have Erlang installed, do
 the following to install and build Lasp.
 
 ```


### PR DESCRIPTION
This brings the README in line with the 'Building Lasp' page on
the website - https://lasp-lang.readme.io/docs/building-lasp.