### PR TITLE
Prevent process leakage.

### DIFF
--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -984,7 +984,12 @@ reply_to_all([From|T], StillWaiting, Result) ->
     reply_to_all(T, StillWaiting, Result);
 reply_to_all([], StillWaiting0, _Result) ->
     GCFun = fun({_, _, From, _, _}) ->
-        is_process_alive(From)
+        case is_pid(From) of
+            true ->
+                is_process_alive(From);
+            false ->
+                true
+        end
     end,
     StillWaiting = lists:filter(GCFun, StillWaiting0),
     {ok, StillWaiting}.

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -982,7 +982,11 @@ reply_to_all([From|T], StillWaiting, Result) ->
             From ! Result
     end,
     reply_to_all(T, StillWaiting, Result);
-reply_to_all([], StillWaiting, _Result) ->
+reply_to_all([], StillWaiting0, _Result) ->
+    GCFun = fun({_, _, From, _, _}) ->
+        is_process_alive(From)
+    end,
+    StillWaiting = lists:filter(GCFun, StillWaiting0),
     {ok, StillWaiting}.
 
 -spec receive_value(store(), {state_send, node(), value(), function(),


### PR DESCRIPTION
Avoid a situtation where single fire processes terminate after receiving the response and stay registered to receive updates on thresholds firing.  Avoids a situtation where the process stays registered and allows the ETS table to grow indefinitely, ultimately crashing the node.