### PR TITLE
refactor: simpler infix append

### DIFF
--- a/simulations/lasp_simulation_support.erl
+++ b/simulations/lasp_simulation_support.erl
@@ -362,4 +362,4 @@ node_list(ClientNumber) ->
 
 %% @private
 client_list(0) -> [];
-client_list(N) -> lists:append(client_list(N - 1), [list_to_atom("client_" ++ integer_to_list(N))]).
+client_list(N) -> client_list(N - 1) ++ [list_to_atom("client_" ++ integer_to_list(N))].

--- a/src/lasp_core.erl
+++ b/src/lasp_core.erl
@@ -590,7 +590,7 @@ read_var(Id, Threshold0, Store, Self, ReplyFun, BlockingFun) ->
                 true ->
                     {Object#dv{lazy_threads=SL}, {ok, {Id, Type, Metadata, Value}}};
                 false ->
-                    WT = lists:append(Object#dv.waiting_threads, [{threshold, read, Self, Type, Threshold}]),
+                    WT = Object#dv.waiting_threads ++ [{threshold, read, Self, Type, Threshold}],
                     {Object#dv{waiting_threads=WT, lazy_threads=SL}, {error, threshold_not_met}}
             end
     end,
@@ -893,9 +893,9 @@ wait_needed(Id, Threshold, Store, Self, ReplyFun, BlockingFun) ->
                     Mutator = fun(Object) ->
                             LazyThreads = case Threshold of
                                             undefined ->
-                                                lists:append(LazyThreads0, [Self]);
+                                                LazyThreads0 ++ [Self];
                                             Threshold ->
-                                                lists:append(LazyThreads0, [{threshold, wait, Self, Type, Threshold}])
+                                                LazyThreads0 ++ [{threshold, wait, Self, Type, Threshold}]
                             end,
                             {Object#dv{lazy_threads=LazyThreads}, ok}
                     end,


### PR DESCRIPTION
refactors instances where infix `++` can replace longer `lists.append(...)` cases