### PR TITLE
don't use priv dir for logs of any kind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ logs/
 erl_crash.dump
 rebar3.crashdump
 dump.rdb
+logs

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ shell:
 plots:
 	pkill -9 beam.smp; \
 	  clear; \
-		rm -rf priv/lager/ priv/evaluation; \
+		rm -rf logs/lager/ logs/evaluation; \
 		(cd priv/ && git clone https://github.com/lasp-lang/evaluation); \
 		./rebar3 ct --readable=false --suite=test/lasp_peer_to_peer_advertisement_counter_SUITE; \
 		./rebar3 ct --readable=false --suite=test/lasp_client_server_advertisement_counter_SUITE; \
@@ -147,10 +147,10 @@ part-div:
 		./rebar3 ct --readable=false --suite=test/lasp_advertisement_counter_partition_overcounting_SUITE
 
 tail-logs:
-	tail -F priv/lager/*/*/log/*.log
+	tail -F logs/lager/*/*/log/*.log
 
 logs:
-	cat priv/lager/*/*/log/*.log
+	cat logs/lager/*/*/log/*.log
 
 DIALYZER_APPS = kernel stdlib erts sasl eunit syntax_tools compiler crypto
 

--- a/simulations/lasp_gui_resource.erl
+++ b/simulations/lasp_gui_resource.erl
@@ -60,10 +60,10 @@ content_types_provided(Req, Ctx) ->
 %% return file path
 -spec file_path(wrq:reqdata() | list()) -> string().
 file_path(Path) when is_list(Path) ->
-    filename:join([code:priv_dir(?APP)] ++ [Path]);
+    filename:join([code:lib_dir(?APP)] ++ [Path]);
 file_path(Req) ->
     Path=wrq:path_tokens(Req),
-    filename:join([code:priv_dir(?APP)] ++ Path).
+    filename:join([code:lib_dir(?APP)] ++ Path).
 
 %% loads a resource file from disk and returns it
 -spec get_file(wrq:reqdata()) -> binary().

--- a/simulations/lasp_instrumentation.erl
+++ b/simulations/lasp_instrumentation.erl
@@ -243,7 +243,7 @@ start_transmission_timer() ->
 
 %% @private
 root_eval_dir() ->
-    code:priv_dir(?APP) ++ "/evaluation".
+    code:lib_dir(?APP) ++ "/evaluation".
 
 %% @private
 root_log_dir() ->

--- a/simulations/lasp_logs_resource.erl
+++ b/simulations/lasp_logs_resource.erl
@@ -37,7 +37,7 @@ content_types_provided(Req, Ctx) ->
     {[{"application/json", to_json}], Req, Ctx}.
 
 to_json(ReqData, State) ->
-    Filenames = filelib:wildcard("*.csv", code:priv_dir(?APP) ++ "/logs"),
+    Filenames = filelib:wildcard("*.csv", code:lib_dir(?APP) ++ "/logs"),
     Filenames1 = [list_to_binary(Filename) || Filename <- Filenames],
     Encoded = jsx:encode(#{logs => Filenames1}),
     {Encoded, ReqData, State}.

--- a/simulations/lasp_plots_resource.erl
+++ b/simulations/lasp_plots_resource.erl
@@ -37,7 +37,7 @@ content_types_provided(Req, Ctx) ->
     {[{"application/json", to_json}], Req, Ctx}.
 
 to_json(ReqData, State) ->
-    Filenames = filelib:wildcard("*.pdf", code:priv_dir(?APP) ++ "/plots"),
+    Filenames = filelib:wildcard("*.pdf", code:lib_dir(?APP) ++ "/plots"),
     Filenames1 = [list_to_binary(Filename) || Filename <- Filenames],
     Encoded = jsx:encode(#{plots => Filenames1}),
     {Encoded, ReqData, State}.

--- a/simulations/lasp_simulation_support.erl
+++ b/simulations/lasp_simulation_support.erl
@@ -96,8 +96,8 @@ start(Case, _Config, Options) ->
     LoaderFun = fun(Node) ->
                             ct:pal("Loading lasp on node: ~p", [Node]),
 
-                            PrivDir = code:priv_dir(?APP),
-                            NodeDir = filename:join([PrivDir, "lager", Case, Node]),
+                            LibDir = code:lib_dir(?APP),
+                            NodeDir = filename:join([LibDir, "logs", "lager", Case, Node]),
 
                             %% Manually force sasl loading, and disable the logger.
                             ok = rpc:call(Node, application, load, [sasl]),

--- a/src/lasp_config.erl
+++ b/src/lasp_config.erl
@@ -55,7 +55,7 @@ web_config() ->
     Config = [
         {ip, Ip},
         {port, Port},
-        {log_dir, "priv/log"},
+        {log_dir, "logs"},
         {dispatch, dispatch()}
     ],
     Node = lasp_support:mynode(),

--- a/src/lasp_support.erl
+++ b/src/lasp_support.erl
@@ -293,8 +293,8 @@ join_to(N, RunnerNode) ->
 load_lasp(Node, _Config, Case) ->
     ct:pal("Loading applications on node: ~p", [Node]),
         
-    PrivDir = code:priv_dir(?APP),
-    NodeDir = filename:join([PrivDir, "lager", Case, Node]),
+    LibDir = code:lib_dir(?APP),
+    NodeDir = filename:join([LibDir, "logs", "lager", Case, Node]),
 
     %% Manually force sasl loading, and disable the logger.
     ok = rpc:call(Node, application, load, [sasl]),

--- a/test/lasp_SUITE.erl
+++ b/test/lasp_SUITE.erl
@@ -391,7 +391,7 @@ sql_run_case(Iterations, Acc, From, To, Row, Threshold0) ->
     sql_run_case(Iterations - 1, [Time | Acc], From, To, Row, NewThreshold).
 
 write_csv(Dir, Option, Cases, Trim) ->
-    Path = code:priv_dir(lasp)
+    Path = code:lib_dir(lasp)
            ++ "/evaluation/logs/"
            ++ atom_to_list(Dir) ++ "/"
            ++ atom_to_list(Option) ++ "/"


### PR DESCRIPTION
Not sure if this is everything, will see if tests pass.

I first noticed this when publishing the package and since I had run tests locally it was going to include a shit load of logs in the package since they were under `priv/` which is a dir for stuff that is part of the application.

If there is anything from old experiments that could be removed (be it the source, samples, stuff in `bin`, etc) that would be helpful.
