### PR TITLE
Update README.md to mention erlang cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Go to node b and retrieve the content of the CRDT:
 3> sets:to_list(AwMapSet).
 % [#{what => i_am_an_awmap_value}]
 ```
+If you try to make a cluster with remote nodes and face an error related to connection attempts from disallowed nodes, you may simply need to put the same erlang.cookie on the machines beforehand to allow them to communicate.
 
 ## Running a shell
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ AwMapType = {state_awmap, [state_mvregister]}.
 
 
 % Update the CRDT with the content
-{ok, _} = lasp:update(AwMap, {apply, Key1, {set, nil, Content}}, self()).
+{ok, _} = lasp:update(AwMap, {apply, Key1, {set, nil, Content}}, term_to_binary(node())).
 ```
 
 Go to node b and retrieve the content of the CRDT:


### PR DESCRIPTION
I initially faced an error when trying to cluster remote nodes together because machines did not share the same erlang.cookie file.
Ended up finding the problem and it went fine after putting the same erlang.cookie on the different machines.
This is just a suggestion but it would probably not hurt to mention it in the readme (especially in the case of beginners who are not used to erlang and distributed systems).

Happy new year 2021 by the way.